### PR TITLE
Default to reversed fg/bg for alternating rows

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -146,12 +146,18 @@ func (root *Root) draw() {
 		// alternate background color
 		if root.Doc.AlternateRows {
 			bgColor := root.ColorNormalBg
+			reverse := false
 			if (root.Doc.lineNum+lY)%2 == 1 {
-				bgColor = ColorAlternate
+				if ColorAlternate == tcell.ColorDefault {
+					// default to reversed colors
+					reverse = true
+				} else {
+					bgColor = ColorAlternate
+				}
 			}
 			for x := 0; x < root.vWidth; x++ {
 				r, c, style, _ := root.GetContent(x, y)
-				root.SetContent(x, y, r, c, style.Background(bgColor))
+				root.SetContent(x, y, r, c, style.Background(bgColor).Reverse(reverse))
 			}
 		}
 		lY = nextY

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -138,7 +138,7 @@ var (
 	// HeaderStyle represents the style of the header.
 	HeaderStyle = tcell.StyleDefault.Bold(true)
 	// ColorAlternate represents alternating colors.
-	ColorAlternate = tcell.ColorGray
+	ColorAlternate = tcell.ColorDefault
 	// OverStrikeStyle represents the overstrike style.
 	OverStrikeStyle = tcell.StyleDefault.Bold(true)
 	// OverLineStyle represents the overline underline style.


### PR DESCRIPTION
If no color is explicitly set in the config file the default is now to
reverse foreground and background colors.

The previous approach of setting it to gray leads to different results
depending on the colorscheme of the used terminal and may in many cases
lead to unreadable lines.