### PR TITLE
Allow reloading file from disk

### DIFF
--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -47,6 +47,7 @@ const (
 	actionNextDoc        = "next_doc"
 	actionPreviousDoc    = "previous_doc"
 	actionToggleMouse    = "toggle_mouse"
+	actionReRead         = "reread"
 )
 
 func (root *Root) setHandler() map[string]func() {
@@ -87,6 +88,7 @@ func (root *Root) setHandler() map[string]func() {
 		actionNextDoc:        root.nextDoc,
 		actionPreviousDoc:    root.previousDoc,
 		actionToggleMouse:    root.toggleMouse,
+		actionReRead:         root.reRead,
 	}
 }
 
@@ -132,6 +134,7 @@ func GetKeyBinds(bind map[string][]string) map[string][]string {
 		actionNextDoc:        {"]"},
 		actionPreviousDoc:    {"["},
 		actionToggleMouse:    {"ctrl+alt+r"},
+		actionReRead:         {"R"},
 	}
 
 	for k, v := range bind {

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -7,6 +7,7 @@ func (root *Root) moveTop() {
 
 // Go to the bottom line.
 func (root *Root) moveBottom() {
+	root.reRead()
 	root.moveLine(root.Doc.endNum + 1)
 }
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -701,6 +701,18 @@ func (root *Root) toggleMouse() {
 	}
 }
 
+func (root *Root) reRead() {
+	root.Doc.lines = nil
+	root.Doc.endNum = 0
+	err := root.Doc.ReadFile(root.Doc.FileName)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	root.Doc.ClearCache()
+	root.viewSync()
+}
+
 func max(a, b int) int {
 	if a > b {
 		return a


### PR DESCRIPTION
This reads the currently displayed file from disk which is helpful for
files that change while being displayed in ov.

Reloading a file by default is bound to the `R` key.

Additionally when jumping to the end of the document it will always be
reloaded as well. This is similar to the behaviour of less.

Closes: #32