### PR TITLE
NewRoot

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -292,6 +293,18 @@ func Open(fileNames ...string) (*Root, error) {
 		return openSTDIN()
 	}
 	return openFiles(fileNames)
+}
+
+func NewRoot(read io.Reader) (*Root, error) {
+	m, err := NewDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = m.ReadAll(io.NopCloser(read)); err != nil {
+		return nil, err
+	}
+	return NewOviewer(m)
 }
 
 func openSTDIN() (*Root, error) {

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -301,7 +301,7 @@ func NewRoot(read io.Reader) (*Root, error) {
 		return nil, err
 	}
 
-	if err = m.ReadAll(io.NopCloser(read)); err != nil {
+	if err = m.ReadAll(read); err != nil {
 		return nil, err
 	}
 	return NewOviewer(m)


### PR DESCRIPTION
This is a convenience function, that returns a Root from a given `io.Reader`. Example code:

~~~go
s := strings.NewReader(strings.Repeat("north\n", 99))
r, e := oviewer.NewRoot(s)
if e != nil {
   panic(e)
}
r.Run()
~~~