### PR TITLE
csToStyle: fix Normal logic

### DIFF
--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -206,8 +206,10 @@ func lastContent(lc lineContents) content {
 // csToStyle returns tcell.Style from the control sequence.
 func csToStyle(style tcell.Style, csiParameter *bytes.Buffer) tcell.Style {
 	fields := strings.Split(csiParameter.String(), ";")
-	if len(fields) == 0 || len(fields) == 1 && fields[0] == "0" {
-		style = tcell.StyleDefault.Normal()
+	if len(fields) == 1 {
+		if fields[0] == "0" || fields[0] == "" {
+			style = tcell.StyleDefault.Normal()
+		}
 	}
 FieldLoop:
 	for index, field := range fields {


### PR DESCRIPTION
`strings.Split` only returns an empty slice, if both arguments are empty [1], which is not the case here. So remove the check for empty slice, and also include empty string in check, to cover both these valid cases:

    \x1b[0m
    \x1b[m

1. https://golang.org/pkg/strings#Split