### PR TITLE
Add FreeBSD installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ sudo rpm -ivh https://github.com/noborus/ov/releases/download/vx.x.x/ov_x.x.x-1_
 brew install noborus/tap/ov
 ```
 
+### pkg (FreeBSD)
+
+```console
+pkg install ov
+```
+
 ### binary
 
 You can download the binary from [releases](https://github.com/noborus/ov/releases).


### PR DESCRIPTION
`ov` has recently been added to the FreeBSD Ports Collection: https://www.freshports.org/textproc/ov/

Cheers!