### PR TITLE
Improved the error of specifying the file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ In other applications, it is pasted from the clipboard (often by pressing the ri
 	Mark position
 
   [m]                        * mark current position
+  [M]                        * remove mark current position
+  [ctrl+delete]              * remove all mark
   [>]                        * move to next marked position
   [<]                        * move to previous marked position
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ var rootCmd = &cobra.Command{
 	Long: `ov is a feature rich pager(such as more/less).
 It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 `,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if config.Debug {
 			fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())


### PR DESCRIPTION
Silent usage set to true.
Output an error and exit, when there is only one file name.
Output log, when there are multiple file names.