### PR TITLE
Avoid seek to check for close errors

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -394,6 +394,7 @@ func openSTDIN() (*Root, error) {
 		return nil, err
 	}
 
+	m.seekable = false
 	if err := m.ReadFile(""); err != nil {
 		return nil, err
 	}

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -178,11 +178,13 @@ func (m *Document) openFollowMode() {
 // Close closes the File.
 // Record the last read position.
 func (m *Document) close() error {
-	pos, err := m.file.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return fmt.Errorf("seek: %w", err)
+	if m.seekable {
+		pos, err := m.file.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return fmt.Errorf("seek: %w", err)
+		}
+		m.offset = pos
 	}
-	m.offset = pos
 	if err := m.file.Close(); err != nil {
 		return fmt.Errorf("close(): %w", err)
 	}


### PR DESCRIPTION
Changed to strictly judge whether seek is possible
because a close error is output.