### PR TITLE
Insufficient move key assignment for `less`

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -93,8 +93,11 @@ KeyBind:
         - "Up"
     top:
         - "Home"
+        - "<"
     bottom:
         - "End"
+        - ">"
+        - "G"
     left:
         - "left"
     right:
@@ -127,16 +130,16 @@ KeyBind:
     remove_all_mark:
         - "ctrl+delete"
     next_mark:
-        - ">"
+        - "alt+>"
     previous_mark:
-        - "<"
+        - "alt+<"
     set_view_mode:
         - "p"
         - "P"
     alter_rows_mode:
         - "C"
     line_number_mode:
-        - "G"
+        - "alt+n"
     search:
         - "/"
     wrap_mode:


### PR DESCRIPTION
Improve #142.
Use `<` and `>` to move to the beginning and end.
Mark movement that has already been assigned is assigned with `alt+`.