### PR TITLE
Before and after also enable WriteOriginal

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 			return err
 		}
 
-		if ov.AfterWrite {
+		if ov.IsWriteOriginal {
 			ov.WriteOriginal()
 		}
 		if ov.Debug {
@@ -153,7 +153,7 @@ func ExecCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if ov.AfterWrite {
+	if ov.IsWriteOriginal {
 		ov.WriteOriginal()
 	}
 	if ov.Debug {
@@ -257,7 +257,13 @@ func init() {
 	_ = viper.BindPFlag("DisableMouse", rootCmd.PersistentFlags().Lookup("disable-mouse"))
 
 	rootCmd.PersistentFlags().BoolP("exit-write", "X", false, "output the current screen when exiting")
-	_ = viper.BindPFlag("AfterWrite", rootCmd.PersistentFlags().Lookup("exit-write"))
+	_ = viper.BindPFlag("IsWriteOriginal", rootCmd.PersistentFlags().Lookup("exit-write"))
+
+	rootCmd.PersistentFlags().IntP("exit-write-before", "b", 0, "NUM before the current lines when exiting")
+	_ = viper.BindPFlag("BeforeWriteOriginal", rootCmd.PersistentFlags().Lookup("exit-write-before"))
+
+	rootCmd.PersistentFlags().IntP("exit-write-after", "a", 0, "NUM after the current lines when exiting")
+	_ = viper.BindPFlag("AfterWriteOriginal", rootCmd.PersistentFlags().Lookup("exit-write-after"))
 
 	rootCmd.PersistentFlags().BoolP("quit-if-one-screen", "F", false, "quit if the output fits on one screen")
 	_ = viper.BindPFlag("QuitSmall", rootCmd.PersistentFlags().Lookup("quit-if-one-screen"))

--- a/ov.yaml
+++ b/ov.yaml
@@ -4,6 +4,8 @@
 # CaseSensitive: false
 # RegexpSearch: false
 # Incsearch: ftrue
+# BeforeWriteOriginal: 1000
+# AfterWriteOriginal: 0
 
 General:
   TabWidth: 8

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -354,6 +354,36 @@ func (root *Root) setWatchInterval(input string) {
 	root.setMessagef("Set watch interval %d", interval)
 }
 
+func (root *Root) setWriteBA(input string) {
+	ba := strings.Split(input, ":")
+	bstr := ba[0]
+	if bstr == "" {
+		bstr = "0"
+	}
+	before, err := strconv.Atoi(bstr)
+	if err != nil {
+		root.setMessage(ErrInvalidNumber.Error())
+		return
+	}
+	root.BeforeWriteOriginal = before
+
+	if len(ba) > 1 {
+		astr := ba[1]
+		if astr == "" {
+			astr = "0"
+		}
+		after, err := strconv.Atoi(astr)
+		if err != nil {
+			root.setMessage(ErrInvalidNumber.Error())
+			return
+		}
+		root.AfterWriteOriginal = after
+	}
+	root.debugMessage(fmt.Sprintf("Before:After:%d:%d", root.BeforeWriteOriginal, root.AfterWriteOriginal))
+	root.IsWriteOriginal = true
+	root.Quit()
+}
+
 // resize is a wrapper function that calls viewSync.
 func (root *Root) resize() {
 	root.ViewSync()

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -75,6 +76,11 @@ type Document struct {
 	topLN int
 	// topLX represents the x position of the top line.
 	topLX int
+	// bottomLN is the last line number displayed.
+	bottomLN int
+	// bottomLX is the leftmost X position on the last line.
+	bottomLX int
+
 	// x is the starting position of the current x.
 	x int
 	// columnNum is the number of columns.
@@ -120,6 +126,21 @@ func (m *Document) GetLine(n int) string {
 		return ""
 	}
 	return m.lines[n]
+}
+
+// CurrentLN returns the currently displayed line number.
+func (m *Document) CurrentLN() int {
+	return m.topLN
+}
+
+// Export exports the document in the specified range.
+func (m *Document) Export(w io.Writer, start int, end int) {
+	for n := start; n <= end; n++ {
+		if n >= m.BufEndNum() {
+			break
+		}
+		fmt.Fprintln(w, m.GetLine(n))
+	}
 }
 
 // BufEndNum return last line number.

--- a/oviewer/document_test.go
+++ b/oviewer/document_test.go
@@ -62,3 +62,53 @@ func TestDocument_lineToContents(t *testing.T) {
 		})
 	}
 }
+
+func TestDocument_Export(t *testing.T) {
+	type args struct {
+		start int
+		end   int
+	}
+	tests := []struct {
+		name  string
+		str   string
+		args  args
+		wantW string
+	}{
+		{
+			name: "test1",
+			str:  "a\nb\nc\nd\ne\n\f\n",
+			args: args{
+				start: 0,
+				end:   2,
+			},
+			wantW: "a\nb\nc\n",
+		},
+		{
+			name: "test2",
+			str:  "a\nb\nc\nd\ne\n\f\n",
+			args: args{
+				start: 1,
+				end:   2,
+			},
+			wantW: "b\nc\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewDocument()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := m.ReadAll(bytes.NewBufferString(tt.str)); err != nil {
+				t.Fatal(err)
+			}
+			w := &bytes.Buffer{}
+			<-m.eofCh
+			m.bottomLN = m.BufEndNum()
+			m.Export(w, tt.args.start, tt.args.end)
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("Document.Export() = %v, want %v", gotW, tt.wantW)
+			}
+		})
+	}
+}

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -35,8 +35,8 @@ func (root *Root) draw() {
 	// Body
 	lX, lY = root.drawBody(lX, lY)
 
-	root.bottomLN = m.topLN + max(lY, 0)
-	root.bottomLX = lX
+	m.bottomLN = m.topLN + max(lY, 0)
+	m.bottomLX = lX
 
 	if root.mouseSelect {
 		root.drawSelect(root.x1, root.y1, root.x2, root.y2, true)

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -152,7 +152,7 @@ func (root *Root) Cancel() {
 
 // WriteQuit sets the write flag and executes a quit event.
 func (root *Root) WriteQuit() {
-	root.AfterWrite = true
+	root.IsWriteOriginal = true
 	root.Quit()
 }
 

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -79,6 +79,8 @@ func (root *Root) main(ctx context.Context, quitChan chan<- struct{}) {
 			root.setTabWidth(ev.value)
 		case *watchIntervalInput:
 			root.setWatchInterval(ev.value)
+		case *writeBAInput:
+			root.setWriteBA(ev.value)
 		case *tcell.EventResize:
 			root.resize()
 		case *tcell.EventMouse:

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	actionExit           = "exit"
+	actionWriteBA        = "exitWriteBA"
 	actionCancel         = "cancel"
 	actionWriteExit      = "write_exit"
 	actionSuspend        = "suspend"
@@ -67,6 +68,7 @@ const (
 func (root *Root) setHandler() map[string]func() {
 	return map[string]func(){
 		actionExit:           root.Quit,
+		actionWriteBA:        root.setWriteBAMode,
 		actionCancel:         root.Cancel,
 		actionWriteExit:      root.WriteQuit,
 		actionSuspend:        root.suspend,
@@ -128,6 +130,7 @@ type KeyBind map[string][]string
 func GetKeyBinds(bind map[string][]string) map[string][]string {
 	keyBind := map[string][]string{
 		actionExit:           {"Escape", "q"},
+		actionWriteBA:        {"ctrl+q"},
 		actionCancel:         {"ctrl+c"},
 		actionWriteExit:      {"Q"},
 		actionSync:           {"ctrl+l"},

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"log"
+	"strings"
 )
 
 // NewLogDoc generates a document for log.
@@ -21,7 +22,7 @@ func NewLogDoc() (*Document, error) {
 // Write matches the interface of io.Writer(so package log is possible).
 // Therefore, the log.Print output is displayed by logDoc.
 func (m *Document) Write(p []byte) (int, error) {
-	str := string(p)
+	str := strings.TrimSuffix(string(p), "\n")
 	m.append(str)
 	return len(str), nil
 }

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -62,9 +62,10 @@ func (root *Root) movePgUp() {
 
 // Moves down one screen.
 func (root *Root) movePgDn() {
+	m := root.Doc
 	root.resetSelect()
-	y := root.bottomLN - root.Doc.firstLine()
-	x := root.bottomLX
+	y := m.bottomLN - m.firstLine()
+	x := m.bottomLX
 	root.limitMoveDown(x, y)
 }
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -95,11 +94,6 @@ type Root struct {
 	// headerLen is the actual header length when wrapped.
 	headerLen int
 
-	// bottomLN is the last line number displayed.
-	bottomLN int
-	// bottomLX is the leftmost X position on the last line.
-	bottomLX int
-
 	// statusPos is the position of the status line.
 	statusPos int
 	// minStartX is the minimum start position of x.
@@ -182,8 +176,15 @@ type Config struct {
 
 	// Mouse support disable.
 	DisableMouse bool
-	// AfterWrite writes the current screen on exit.
-	AfterWrite bool
+	// IsWriteOriginal is true, write the current screen on quit.
+	IsWriteOriginal bool
+	// BeforeWriteOriginal specifies the number of lines before the current position.
+	// 0 is the top of the current screen
+	BeforeWriteOriginal int
+	// AfterWriteOriginal specifies the number of lines after the current position.
+	// 0 specifies the bottom of the screen.
+	AfterWriteOriginal int
+
 	// QuiteSmall Quit if the output fits on one screen.
 	QuitSmall bool
 	// CaseSensitive is case-sensitive if true.
@@ -251,6 +252,8 @@ const (
 	// LogDoc is Error screen mode.
 	LogDoc
 )
+
+const MaxWriteLog int = 10
 
 var (
 	// ErrOutOfRange indicates that value is out of range.
@@ -575,7 +578,7 @@ func (root *Root) Run() error {
 	root.ViewSync()
 	// Exit if fits on screen
 	if root.QuitSmall && root.docSmall() {
-		root.AfterWrite = true
+		root.IsWriteOriginal = true
 		return nil
 	}
 
@@ -750,38 +753,25 @@ func (root *Root) docSmall() bool {
 // WriteOriginal writes to the original terminal.
 func (root *Root) WriteOriginal() {
 	m := root.Doc
-	p := 0
-	for n := m.topLN; ; n++ {
-		if n >= m.BufEndNum() {
-			break
-		}
-
-		lc, err := m.contentsLN(n, root.Doc.TabWidth)
-		if err != nil {
-			log.Println(err, n)
-			continue
-		}
-		p += 1 + (len(lc) / root.vWidth)
-		if p >= root.vHight {
-			break
-		}
-
-		fmt.Println(m.GetLine(n))
+	if m.bottomLN == 0 {
+		m.bottomLN = m.BufEndNum()
 	}
+
+	start := max(0, m.topLN-root.BeforeWriteOriginal)
+	end := m.bottomLN
+	if root.AfterWriteOriginal != 0 {
+		end = m.topLN + root.AfterWriteOriginal - 1
+	}
+
+	m.Export(os.Stdout, start, end)
 }
 
 // WriteLog write to the log terminal.
 func (root *Root) WriteLog() {
-	maxWriteLog := 10
 	m := root.logDoc
-
-	n := m.BufEndNum() - maxWriteLog
-	for i := 0; i < maxWriteLog; i++ {
-		str := strings.ReplaceAll(m.GetLine(n+i), "\n", "")
-		if len(str) > 0 {
-			fmt.Fprintln(os.Stderr, str)
-		}
-	}
+	start := max(0, m.BufEndNum()-MaxWriteLog)
+	end := m.BufEndNum()
+	m.Export(os.Stdout, start, end)
 }
 
 // leftMostX returns a list of left - most x positions when wrapping.


### PR DESCRIPTION
Enables writeOriginal to be output by specifying the lines
before and after the current line.
Writing the settings in ~/.ov.yaml is similar to the behavior
of `less -X`.

BeforeWriteOriginal: 1000

Added cli options write-exit-before(b) and write-exit-after(a)
(cli option takes precedence).

If the value of write-exit-after is set to 0,
it will be the current screen height.

Added CurrentLN() to the document to return the number of current line.

Added Export() to output the specified line(range) from the document.

Fix #48.
A discussion of this fix was made in #146. Thank you @aranjan7.