### PR TITLE
abolished setOldGlobalStyle

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,9 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 		// stream mode must be set first.
 		oviewer.StreamMode = config.Stream
 
+		oviewer.OverStrikeStyle = oviewer.ToTcellStyle(config.StyleOverStrike)
+		oviewer.OverLineStyle = oviewer.ToTcellStyle(config.StyleOverLine)
+
 		if ver {
 			fmt.Printf("ov version %s rev:%s\n", Version, Revision)
 			return nil

--- a/oviewer/content_test.go
+++ b/oviewer/content_test.go
@@ -2,15 +2,22 @@ package oviewer
 
 import (
 	"bytes"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
 )
 
-func SetupStyle() {
-	OverStrikeStyle = setStyle(ovStyle{Bold: true})
-	OverLineStyle = setStyle(ovStyle{Underline: true})
+func setup() {
+	OverStrikeStyle = ToTcellStyle(ovStyle{Bold: true})
+	OverLineStyle = ToTcellStyle(ovStyle{Underline: true})
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	ret := m.Run()
+	os.Exit(ret)
 }
 
 func Test_parseString(t *testing.T) {
@@ -271,7 +278,6 @@ func Test_parseString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		SetupStyle()
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseString(tt.args.line, tt.args.tabWidth)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -331,7 +337,6 @@ func Test_parseStringCombining(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		SetupStyle()
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseString(tt.args.line, tt.args.tabWidth)
 			if !reflect.DeepEqual(got, tt.want) {

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -562,7 +562,6 @@ func (root *Root) Run() error {
 			doc.WatchMode = true
 		}
 	}
-	root.setGlobalStyle()
 	root.Screen.Clear()
 
 	list := make([]string, 0, len(root.Config.Mode)+1)
@@ -641,7 +640,7 @@ func (root *Root) debugMessage(msg string) {
 	log.Printf("%s:%s", root.Doc.FileName, msg)
 }
 
-func setStyle(s ovStyle) tcell.Style {
+func ToTcellStyle(s ovStyle) tcell.Style {
 	style := tcell.StyleDefault
 	style = style.Background(tcell.GetColor(s.Background))
 	style = style.Foreground(tcell.GetColor(s.Foreground))
@@ -685,28 +684,6 @@ func applyStyle(style tcell.Style, s ovStyle) tcell.Style {
 		style = style.StrikeThrough(s.StrikeThrough)
 	}
 	return style
-}
-
-func (root *Root) setGlobalStyle() {
-	OverStrikeStyle = setStyle(root.Config.StyleOverStrike)
-	OverLineStyle = setStyle(root.Config.StyleOverLine)
-	root.setOldGlobalStyle()
-}
-
-// setGlobalStyle sets some styles that are determined by the settings.
-func (root *Root) setOldGlobalStyle() {
-	if root.ColorAlternate != "" {
-		root.StyleAlternate = ovStyle{Background: root.ColorAlternate}
-	}
-	if root.ColorHeader != "" {
-		root.StyleHeader = ovStyle{Foreground: root.ColorHeader}
-	}
-	if root.ColorOverStrike != "" {
-		OverStrikeStyle = OverStrikeStyle.Foreground(tcell.GetColor(root.ColorOverStrike))
-	}
-	if root.ColorOverLine != "" {
-		OverLineStyle = OverLineStyle.Foreground(tcell.GetColor(root.ColorOverLine))
-	}
 }
 
 // prepareView prepares when the screen size is changed.


### PR DESCRIPTION
OverStrikeStyle and OverLineStyle must be set before parse
to prevent race conditions.
setOldGlobalStyle is abolished
because it became difficult to set without collision.