### PR TITLE
Changed not to clear the whole

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -411,6 +411,6 @@ func (root *Root) prepareStartX() {
 func (root *Root) updateEndNum() {
 	root.debugMessage(fmt.Sprintf("Update EndNum:%d", root.Doc.BufEndNum()))
 	root.prepareStartX()
-	root.statusDraw()
+	root.drawStatus()
 	root.Screen.Sync()
 }

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -127,15 +127,32 @@ func OpenDocument(fileName string) (*Document, error) {
 	if fi.IsDir() {
 		return nil, fmt.Errorf("%s %w", fileName, ErrIsDirectory)
 	}
+
 	m, err := NewDocument()
 	if err != nil {
 		return nil, err
 	}
 
+	// named pipe.
 	if fi.Mode()&fs.ModeNamedPipe != 0 {
 		m.seekable = false
 	}
+
 	if err := m.ReadFile(fileName); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// STDINDocument returns a Document that reads stdin.
+func STDINDocument() (*Document, error) {
+	m, err := NewDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	m.seekable = false
+	if err := m.ReadFile(""); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -112,6 +113,29 @@ func NewDocument() (*Document, error) {
 	}
 
 	if err := m.NewCache(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// OpenDocument opens a file and returns a Document.
+func OpenDocument(fileName string) (*Document, error) {
+	fi, err := os.Stat(fileName)
+	if err != nil {
+		return nil, err
+	}
+	if fi.IsDir() {
+		return nil, fmt.Errorf("%s %w", fileName, ErrIsDirectory)
+	}
+	m, err := NewDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	if fi.Mode()&fs.ModeNamedPipe != 0 {
+		m.seekable = false
+	}
+	if err := m.ReadFile(fileName); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -14,10 +14,9 @@ const statusline = 1
 func (root *Root) draw() {
 	m := root.Doc
 
-	root.Screen.Clear()
 	if root.vHight == 0 {
 		m.topLN = 0
-		root.statusDraw()
+		root.drawStatus()
 		root.Show()
 		return
 	}
@@ -42,7 +41,7 @@ func (root *Root) draw() {
 		root.drawSelect(root.x1, root.y1, root.x2, root.y2, true)
 	}
 
-	root.statusDraw()
+	root.drawStatus()
 	root.Show()
 }
 
@@ -210,6 +209,7 @@ func (root *Root) drawWrapLine(y int, lX int, lY int, lc lineContents) (int, int
 	for x := 0; ; x++ {
 		if lX+x >= len(lc) {
 			// EOL
+			root.clearEOL(root.startX+x, y)
 			lX = 0
 			lY++
 			break
@@ -235,6 +235,7 @@ func (root *Root) drawNoWrapLine(y int, lX int, lY int, lc lineContents) (int, i
 	for x := 0; root.startX+x < root.vWidth; x++ {
 		if lX+x >= len(lc) {
 			// EOL
+			root.clearEOL(root.startX+x, y)
 			break
 		}
 		content := DefaultContent
@@ -270,8 +271,9 @@ func RangeStyle(lc lineContents, start int, end int, style ovStyle) {
 	}
 }
 
-// statusDraw draws a status line.
-func (root *Root) statusDraw() {
+// drawStatus draws a status line.
+func (root *Root) drawStatus() {
+	root.clearEOL(0, root.statusPos)
 	leftContents, cursorPos := root.leftStatus()
 	root.setContentString(0, root.statusPos, leftContents)
 
@@ -359,4 +361,11 @@ func (root *Root) setContentString(vx int, vy int, lc lineContents) {
 		screen.SetContent(vx+x, vy, content.mainc, content.combc, content.style)
 	}
 	screen.SetContent(vx+len(lc), vy, 0, nil, tcell.StyleDefault.Normal())
+}
+
+// clearEOL clears from the specified position to the right end.
+func (root *Root) clearEOL(x int, y int) {
+	for ; x < root.vWidth; x++ {
+		root.Screen.SetContent(root.startX+x, y, ' ', nil, tcell.StyleDefault)
+	}
 }

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -378,18 +378,11 @@ func Open(fileNames ...string) (*Root, error) {
 
 // openSTDIN creates root with standard input.
 func openSTDIN() (*Root, error) {
-	docList := make([]*Document, 0, 1)
-	m, err := NewDocument()
+	m, err := STDINDocument()
 	if err != nil {
 		return nil, err
 	}
-
-	m.seekable = false
-	if err := m.ReadFile(""); err != nil {
-		return nil, err
-	}
-	docList = append(docList, m)
-	return NewOviewer(docList...)
+	return NewOviewer(m)
 }
 
 // openFile creates root in one file.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -555,7 +555,6 @@ func (root *Root) Run() error {
 			doc.WatchMode = true
 		}
 	}
-	root.Screen.Clear()
 
 	list := make([]string, 0, len(root.Config.Mode)+1)
 	list = append(list, "general")

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -3,11 +3,16 @@ package oviewer
 import (
 	"bytes"
 	"io"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
 )
+
+const cwd = ".."
+
+var testdata = filepath.Join(cwd, "testdata")
 
 func fakeScreen() (tcell.Screen, error) {
 	return tcell.NewSimulationScreen(""), nil
@@ -64,7 +69,7 @@ func TestOpen(t *testing.T) {
 		{
 			name: "test1",
 			args: args{
-				fileNames: []string{"../testdata/test.txt"},
+				fileNames: []string{filepath.Join(testdata, "/test.txt")},
 			},
 			wantErr: false,
 		},
@@ -72,8 +77,8 @@ func TestOpen(t *testing.T) {
 			name: "test2",
 			args: args{
 				fileNames: []string{
-					"../testdata/test.txt",
-					"../testdata/test2.txt",
+					filepath.Join(testdata, "test.txt"),
+					filepath.Join(testdata, "test2.txt"),
 				},
 			},
 			wantErr: false,
@@ -81,14 +86,14 @@ func TestOpen(t *testing.T) {
 		{
 			name: "testErr",
 			args: args{
-				fileNames: []string{"../testdata/err.txt"},
+				fileNames: []string{filepath.Join(testdata, "err.txt")},
 			},
 			wantErr: true,
 		},
 		{
 			name: "testDir",
 			args: args{
-				fileNames: []string{"../testdata/"},
+				fileNames: []string{testdata},
 			},
 			wantErr: true,
 		},
@@ -162,7 +167,7 @@ func TestRoot_Run(t *testing.T) {
 				TabWidth:       8,
 				MarkStyleWidth: 1,
 			},
-			ovArgs:  []string{"../testdata/test.txt"},
+			ovArgs:  []string{filepath.Join(testdata, "test.txt")},
 			wantErr: false,
 		},
 		{
@@ -172,7 +177,7 @@ func TestRoot_Run(t *testing.T) {
 				MarkStyleWidth: 1,
 				Header:         1,
 			},
-			ovArgs:  []string{"../testdata/test.txt"},
+			ovArgs:  []string{filepath.Join(testdata, "test.txt")},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Sometimes screen.Clear() flickers on windows terminal.
Therefore, stop clearing the whole.
This may improve #144.

Fixed openFile not being aligned with others by refactoring.