### PR TITLE
Fixed docSmall() not working for NewRoot

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -349,15 +349,12 @@ func NewConfig() Config {
 
 // NewRoot returns the structure of the oviewer.
 // NewRoot is a simplified version that can be used externally.
-func NewRoot(read io.Reader) (*Root, error) {
+func NewRoot(r io.Reader) (*Root, error) {
 	m, err := NewDocument()
 	if err != nil {
 		return nil, err
 	}
-	go func() {
-		<-m.eofCh
-	}()
-	if err := m.ReadAll(read); err != nil {
+	if err := m.ReadReader(r); err != nil {
 		return nil, err
 	}
 	return NewOviewer(m)

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -354,6 +354,9 @@ func NewRoot(read io.Reader) (*Root, error) {
 	if err != nil {
 		return nil, err
 	}
+	go func() {
+		<-m.eofCh
+	}()
 	if err := m.ReadAll(read); err != nil {
 		return nil, err
 	}

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -249,6 +249,16 @@ func (m *Document) ReadAll(r io.Reader) error {
 	return nil
 }
 
+// ReadReader reads reader.
+// A wrapper for ReadAll, used when eofCh notifications are not needed.
+func (m *Document) ReadReader(r io.Reader) error {
+	go func() {
+		<-m.eofCh
+	}()
+
+	return m.ReadAll(r)
+}
+
 // ContinueReadAll continues to read even if it reaches EOF.
 func (m *Document) ContinueReadAll(ctx context.Context, r io.Reader) error {
 	reader := bufio.NewReader(r)


### PR DESCRIPTION
Because eofCh reception was insufficient at the time of New Root.
This commit fix #164