### PR TITLE
Fixed clear leak at the right end

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -160,8 +160,9 @@ func (root *Root) drawWrapLine(y int, lX int, lY int, lc lineContents) (int, int
 			break
 		}
 		content := lc[lX+x]
-		if x+content.width+root.startX > root.vWidth {
+		if x+root.startX+content.width > root.vWidth {
 			// Right edge.
+			root.clearEOL(root.startX+x, y)
 			lX += x
 			break
 		}


### PR DESCRIPTION
If the character with width 2 is at the right end,
the rightmost width 1 may be empty.