### PR TITLE
Fixed to work when the config file doesn't exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,12 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if config.Debug {
-			fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+			cfg := viper.ConfigFileUsed()
+			if cfg != "" {
+				fmt.Fprintln(os.Stderr, "Using config file:", cfg)
+			} else {
+				fmt.Fprintln(os.Stderr, "config file not found")
+			}
 		}
 
 		if ver {
@@ -314,10 +319,7 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", viper.ConfigFileUsed(), err.Error())
-		return
-	}
+	_ = viper.ReadInConfig()
 	if err := viper.Unmarshal(&config); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return

--- a/main.go
+++ b/main.go
@@ -302,8 +302,8 @@ func initConfig() {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			fmt.Fprintln(os.Stderr, err)
+			return
 		}
 
 		// Search config in home directory with name ".ov" (without extension).
@@ -315,12 +315,12 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Printf("%s: %s\n", viper.ConfigFileUsed(), err.Error())
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "%s: %s\n", viper.ConfigFileUsed(), err.Error())
+		return
 	}
 	if err := viper.Unmarshal(&config); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 }
 


### PR DESCRIPTION
Do not exit with initConfig.