### PR TITLE
Disable default keybindings

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 // HelpKey displays key bindings and exits.
 func HelpKey(cmd *cobra.Command, _ []string) {
 	fmt.Println(cmd.Short)
-	keyBind := oviewer.GetKeyBinds(config.Keybind)
+	keyBind := oviewer.GetKeyBinds(config)
 	fmt.Println(oviewer.KeyBindString(keyBind))
 }
 

--- a/ov-disable-default.yaml
+++ b/ov-disable-default.yaml
@@ -1,0 +1,11 @@
+# Disable the default keybindings.
+# Only keybindings set here will be enabled.
+DefaultKeyBind: "disable"
+KeyBind:
+    exit:
+        - "Escape"
+        - "q"
+    down:
+        - "Down"
+    up:
+        - "Up"

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -21,7 +21,7 @@ func (root *Root) toggleWrapMode() {
 	root.setMessagef("Set WrapMode %t", root.Doc.WrapMode)
 }
 
-//  toggleColumnMode toggles ColumnMode each time it is called.
+// toggleColumnMode toggles ColumnMode each time it is called.
 func (root *Root) toggleColumnMode() {
 	root.Doc.ColumnMode = !root.Doc.ColumnMode
 	root.setMessagef("Set ColumnMode %t", root.Doc.ColumnMode)

--- a/oviewer/doc.go
+++ b/oviewer/doc.go
@@ -9,20 +9,20 @@ So if you want to do something in concurrent, you need to use goroutine.
 There is also a simple usage example below:
 https://github.com/noborus/mdviewer/
 
-  package main
+	package main
 
-  import (
-      "github.com/noborus/ov/oviewer"
-  )
+	import (
+	    "github.com/noborus/ov/oviewer"
+	)
 
-  func main() {
-      ov, err := oviewer.Open("main.go")
-      if err != nil {
-        panic(err)
-      }
-      if err := ov.Run(); err != nil {
-        panic(err)
-      }
-  }
+	func main() {
+	    ov, err := oviewer.Open("main.go")
+	    if err != nil {
+	      panic(err)
+	    }
+	    if err := ov.Run(); err != nil {
+	      panic(err)
+	    }
+	}
 */
 package oviewer

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -136,9 +136,8 @@ func (root *Root) setHandler() map[string]func() {
 // KeyBind is the mapping of action and key.
 type KeyBind map[string][]string
 
-// GetKeyBinds returns the current key mapping.
-func GetKeyBinds(bind map[string][]string) map[string][]string {
-	keyBind := map[string][]string{
+func defaultKeyBinds() map[string][]string {
+	return map[string][]string{
 		actionExit:           {"Escape", "q"},
 		actionWriteBA:        {"ctrl+q"},
 		actionCancel:         {"ctrl+c"},
@@ -199,11 +198,22 @@ func GetKeyBinds(bind map[string][]string) map[string][]string {
 		inputIncSearch:     {"alt+i"},
 		inputRegexpSearch:  {"alt+r"},
 	}
+}
 
+// GetKeyBinds returns the current key mapping.
+func GetKeyBinds(config Config) map[string][]string {
+	keyBind := make(map[string][]string)
+	if strings.ToLower(config.DefaultKeyBind) != "disable" {
+		keyBind = defaultKeyBinds()
+	}
+	keyBind = updateKeyBind(keyBind, config.Keybind)
+	return keyBind
+}
+
+func updateKeyBind(keyBind map[string][]string, bind map[string][]string) map[string][]string {
 	for k, v := range bind {
 		keyBind[k] = v
 	}
-
 	return keyBind
 }
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -195,6 +195,8 @@ type Config struct {
 	// Debug represents whether to enable the debug output.
 	Debug bool
 
+	// Default keybindings. Disabled if the default keybinding is "disable".
+	DefaultKeyBind string
 	// KeyBinding
 	Keybind map[string][]string
 
@@ -480,7 +482,7 @@ func (root *Root) SetWatcher(watcher *fsnotify.Watcher) {
 }
 
 func (root *Root) setKeyConfig() (map[string][]string, error) {
-	keyBind := GetKeyBinds(root.Config.Keybind)
+	keyBind := GetKeyBinds(root.Config)
 	if err := root.setKeyBind(keyBind); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set **DefaultKeyBind:** to "disable".
This setting requires keybindings to be set appropriately.

An example of a setting that only allows exit and
forward/backward movement.

```console
ov --config ov-disable-default.yaml README.md
```