### PR TITLE
Updated goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,34 +2,23 @@ name: release
 on:
   push:
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "*"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      - name: Generate release tarball
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          tar czf ov-${VERSION}.tar.gz --transform "s,^,ov-${VERSION}/," --exclude dist *
-      - name: Upload release tarball
-        uses: softprops/action-gh-release@master
-        with:
-          files: ov-*.tar.gz
-          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,3 +80,8 @@ brews:
       system "#{bin}/ov --version"
     install:
       bin.install "ov"
+
+source:
+  enabled: true
+  files:
+    - vendor


### PR DESCRIPTION
goreleaser can now create a tar with the vendor included. Abolished uploading that was done with github actions.