### PR TITLE
Added plain mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/ulikunitz/xz v0.5.10
-	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
+	golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20221106115401-f9659909a136 h1:Fq7F/w7MAa1KJ5bt2aJ62ihqp9HDcRuyILskkpIAurw=
-golang.org/x/exp v0.0.0-20221106115401-f9659909a136/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab h1:1S7USr8/C0Sgk4egxq4zZ07zYt2Xh1IiFp8hUMXH/us=
+golang.org/x/exp v0.0.0-20221111204811-129d8d6c17ab/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/main.go
+++ b/main.go
@@ -248,6 +248,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("wrap", "w", true, "wrap mode")
 	_ = viper.BindPFlag("general.WrapMode", rootCmd.PersistentFlags().Lookup("wrap"))
 
+	rootCmd.PersistentFlags().BoolP("plain", "", true, "plain mode")
+	_ = viper.BindPFlag("general.PlainMode", rootCmd.PersistentFlags().Lookup("plain"))
+
 	rootCmd.PersistentFlags().StringP("column-delimiter", "d", ",", "column delimiter")
 	_ = viper.BindPFlag("general.ColumnDelimiter", rootCmd.PersistentFlags().Lookup("column-delimiter"))
 	_ = rootCmd.RegisterFlagCompletionFunc("column-delimiter", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -55,6 +55,11 @@ func (root *Root) toggleFollowSection() {
 	root.Doc.FollowSection = !root.Doc.FollowSection
 }
 
+// togglePlain toggles follow section mode.
+func (root *Root) togglePlain() {
+	root.Doc.PlainMode = !root.Doc.PlainMode
+}
+
 // closeFile close the file.
 func (root *Root) closeFile() {
 	if root.screenMode != Docs {

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -112,6 +112,7 @@ func NewDocument() (*Document, error) {
 			ColumnDelimiter: "",
 			TabWidth:        8,
 			MarkStyleWidth:  1,
+			PlainMode:       true,
 		},
 		lastContentsNum: -1,
 		seekable:        true,

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -116,6 +116,9 @@ func (root *Root) drawBody(lX int, lY int) (int, int) {
 		}
 
 		root.columnHighlight(lc, lineStr, posCV)
+		if root.Doc.PlainMode {
+			root.plainMode(lc)
+		}
 		root.multiColorHighlight(lc, lineStr, posCV)
 		root.searchHighlight(lY, lc, lineStr, posCV)
 		root.drawLineNumber(lY, y)
@@ -213,6 +216,12 @@ func (root *Root) searchHighlight(lY int, lc contents, lineStr string, posCV map
 	poss := root.searchPosition(lY, lineStr)
 	for _, r := range poss {
 		RangeStyle(lc, posCV[r[0]], posCV[r[1]], root.StyleSearchHighlight)
+	}
+}
+
+func (root *Root) plainMode(lc contents) {
+	for x := 0; x < len(lc); x++ {
+		lc[x].style = tcell.StyleDefault
 	}
 }
 

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -18,6 +18,7 @@ const (
 	actionFollow         = "follow_mode"
 	actionFollowAll      = "follow_all"
 	actionFollowSection  = "follow_section"
+	actionPlain          = "plain_mode"
 	actionCloseFile      = "close_file"
 	actionReload         = "reload"
 	actionWatch          = "watch"
@@ -82,6 +83,7 @@ func (root *Root) setHandler() map[string]func() {
 		actionFollow:         root.toggleFollowMode,
 		actionFollowAll:      root.toggleFollowAll,
 		actionFollowSection:  root.toggleFollowSection,
+		actionPlain:          root.togglePlain,
 		actionReload:         root.Reload,
 		actionWatch:          root.toggleWatch,
 		actionWatchInterval:  root.setWatchIntervalMode,
@@ -149,6 +151,7 @@ func defaultKeyBinds() map[string][]string {
 		actionFollow:         {"ctrl+f"},
 		actionFollowAll:      {"ctrl+a"},
 		actionFollowSection:  {"F2"},
+		actionPlain:          {"ctrl+e"},
 		actionCloseFile:      {"ctrl+F9", "ctrl+alt+s"},
 		actionReload:         {"F5", "ctrl+alt+l"},
 		actionWatch:          {"F4", "ctrl+alt+w"},

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -133,6 +133,8 @@ type general struct {
 	FollowAll bool
 	// FollowSection is a follow mode that uses section instead of line.
 	FollowSection bool
+	// PlainMode is whether to enable the original character decoration.
+	PlainMode bool
 	// WatchInterval is the watch interval (seconds).
 	WatchInterval int
 	// MarkStyleWidth is width to apply the style of the marked line.


### PR DESCRIPTION
Plain mode disables the original escape sequences. Plain mode works with the `--plain` option
or toggle with the default (ctrl+e) key.