### PR TITLE
Added jump target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/ulikunitz/xz v0.5.10
-	golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb
+	golang.org/x/exp v0.0.0-20221207211629-99ab8fa1c11f
 	golang.org/x/sync v0.1.0
-	golang.org/x/term v0.2.0
+	golang.org/x/term v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb h1:QIsP/NmClBICkqnJ4rSIhnrGiGR7Yv9ZORGGnmmLTPk=
-golang.org/x/exp v0.0.0-20221204150635-6dcec336b2bb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20221207211629-99ab8fa1c11f h1:90Jq/vvGVDsqj8QqCynjFw9MCerDguSMODLYII416Y8=
+golang.org/x/exp v0.0.0-20221207211629-99ab8fa1c11f/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -368,8 +368,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
-golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
+golang.org/x/term v0.3.0 h1:qoo4akIqOcDME5bhc/NgxUdovd6BSS2uMsVjB56q1xI=
+golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -275,8 +275,8 @@ func init() {
 	rootCmd.PersistentFlags().IntP("watch", "T", 0, "watch mode interval")
 	_ = viper.BindPFlag("general.WatchInterval", rootCmd.PersistentFlags().Lookup("watch"))
 
-	rootCmd.PersistentFlags().IntP("jump-target", "j", 0, "jump-target")
-	_ = viper.BindPFlag("general.JumpTarget", rootCmd.PersistentFlags().Lookup("jump-target"))
+	rootCmd.PersistentFlags().StringP("jump-target", "j", "", "jump-target")
+	_ = viper.BindPFlag("general.JumpTargetString", rootCmd.PersistentFlags().Lookup("jump-target"))
 
 	// Config
 	rootCmd.PersistentFlags().BoolP("disable-mouse", "", false, "disable mouse support")

--- a/main.go
+++ b/main.go
@@ -275,6 +275,9 @@ func init() {
 	rootCmd.PersistentFlags().IntP("watch", "T", 0, "watch mode interval")
 	_ = viper.BindPFlag("general.WatchInterval", rootCmd.PersistentFlags().Lookup("watch"))
 
+	rootCmd.PersistentFlags().IntP("jump-target", "j", 0, "jump-target")
+	_ = viper.BindPFlag("general.JumpTarget", rootCmd.PersistentFlags().Lookup("jump-target"))
+
 	// Config
 	rootCmd.PersistentFlags().BoolP("disable-mouse", "", false, "disable mouse support")
 	_ = viper.BindPFlag("DisableMouse", rootCmd.PersistentFlags().Lookup("disable-mouse"))

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -445,6 +445,26 @@ func (root *Root) setMultiColor(input string) {
 	root.setMessagef("Set multicolor strings [%s]", input)
 }
 
+// setJumpTarget sets the position of the search result.
+func (root *Root) setJumpTarget(input string) {
+	log.Println("setJump")
+	num, err := strconv.Atoi(input)
+	if err != nil {
+		root.setMessagef("Set JumpTarget: %s", ErrInvalidNumber.Error())
+		return
+	}
+	if num < 0 || num > root.vHight-1 {
+		root.setMessagef("Set JumpTarget %d: %s", num, ErrOutOfRange.Error())
+		return
+	}
+	if root.Doc.JumpTarget == num {
+		return
+	}
+
+	root.Doc.JumpTarget = num
+	root.setMessagef("Set JumpTarget %d", num)
+}
+
 // resize is a wrapper function that calls viewSync.
 func (root *Root) resize() {
 	root.ViewSync()

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -128,6 +128,9 @@ func (root *Root) drawBody(lX int, lY int) (int, int) {
 		root.alternateRowsStyle(currentY, y)
 		root.markStyle(currentY, y, markStyleWidth)
 		root.sectionLineHighlight(y, lineStr)
+		if root.Doc.JumpTarget != 0 && root.headerLen+root.Doc.JumpTarget == y {
+			root.lineStyle(y, root.StyleJumpTargetLine)
+		}
 
 		if lX > 0 {
 			wrapNum++

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -58,10 +58,12 @@ func (root *Root) main(ctx context.Context, quitChan chan<- struct{}) {
 			root.getClipboard(ctx)
 		case *eventSearch:
 			searcher := root.setSearcher(ev.str, root.CaseSensitive)
-			root.searchMove(ctx, true, root.Doc.topLN+root.Doc.firstLine()+1, searcher)
+			l := root.lnumber[root.headerLen+root.Doc.JumpTarget]
+			root.searchMove(ctx, true, l.line+1, searcher)
 		case *eventBackSearch:
 			searcher := root.setSearcher(ev.str, root.CaseSensitive)
-			root.searchMove(ctx, false, root.Doc.topLN+root.Doc.firstLine()-1, searcher)
+			l := root.lnumber[root.headerLen+root.Doc.JumpTarget]
+			root.searchMove(ctx, false, l.line-1, searcher)
 		case *viewModeInput:
 			root.setViewMode(ev.value)
 		case *searchInput:
@@ -90,6 +92,8 @@ func (root *Root) main(ctx context.Context, quitChan chan<- struct{}) {
 			root.setSectionStart(ev.value)
 		case *multiColorInput:
 			root.setMultiColor(ev.value)
+		case *jumpTargetInput:
+			root.setJumpTarget(ev.value)
 		case *tcell.EventResize:
 			root.resize()
 		case *tcell.EventMouse:

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -58,11 +58,11 @@ func (root *Root) main(ctx context.Context, quitChan chan<- struct{}) {
 			root.getClipboard(ctx)
 		case *eventSearch:
 			searcher := root.setSearcher(ev.str, root.CaseSensitive)
-			l := root.lnumber[root.headerLen+root.Doc.JumpTarget]
+			l := root.lineNumber(root.headerLen + root.Doc.JumpTarget)
 			root.searchMove(ctx, true, l.line+1, searcher)
 		case *eventBackSearch:
 			searcher := root.setSearcher(ev.str, root.CaseSensitive)
-			l := root.lnumber[root.headerLen+root.Doc.JumpTarget]
+			l := root.lineNumber(root.headerLen + root.Doc.JumpTarget)
 			root.searchMove(ctx, false, l.line-1, searcher)
 		case *viewModeInput:
 			root.setViewMode(ev.value)

--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -555,10 +555,8 @@ func (g *gotoInput) Prompt() string {
 // Confirm returns the event when the input is confirmed.
 func (g *gotoInput) Confirm(str string) tcell.Event {
 	g.value = str
-	if _, err := strconv.Atoi(str); err == nil {
-		g.clist.list = toLast(g.clist.list, str)
-		g.clist.p = 0
-	}
+	g.clist.list = toLast(g.clist.list, str)
+	g.clist.p = 0
 	g.SetEventNow()
 	return g
 }
@@ -987,10 +985,8 @@ func (j *jumpTargetInput) Prompt() string {
 // Confirm returns the event when the input is confirmed.
 func (j *jumpTargetInput) Confirm(str string) tcell.Event {
 	j.value = str
-	if _, err := strconv.Atoi(str); err == nil {
-		j.clist.list = toLast(j.clist.list, str)
-		j.clist.p = 0
-	}
+	j.clist.list = toLast(j.clist.list, str)
+	j.clist.p = 0
 	j.SetEventNow()
 	return j
 }
@@ -1003,14 +999,4 @@ func (g *jumpTargetInput) Up(str string) string {
 // Down returns strings when the down key is pressed during input.
 func (g *jumpTargetInput) Down(str string) string {
 	return g.clist.down()
-}
-
-func toLast(list []string, s string) []string {
-	if len(s) == 0 {
-		return list
-	}
-
-	list = remove(list, s)
-	list = append(list, s)
-	return list
 }

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -66,6 +66,7 @@ const (
 	actionCloseDoc       = "close_doc"
 	actionToggleMouse    = "toggle_mouse"
 	actionMultiColor     = "multi_color"
+	actionJumpTarget     = "jump_target"
 
 	inputCaseSensitive = "input_casesensitive"
 	inputIncSearch     = "input_incsearch"
@@ -131,6 +132,7 @@ func (root *Root) setHandler() map[string]func() {
 		actionCloseDoc:       root.closeDocument,
 		actionToggleMouse:    root.toggleMouse,
 		actionMultiColor:     root.setMultiColorMode,
+		actionJumpTarget:     root.setJumpTargetMode,
 
 		inputCaseSensitive: root.inputCaseSensitive,
 		inputIncSearch:     root.inputIncSearch,
@@ -200,6 +202,7 @@ func defaultKeyBinds() map[string][]string {
 		actionToggleMouse:    {"ctrl+alt+r"},
 		actionSuspend:        {"ctrl+z"},
 		actionMultiColor:     {"."},
+		actionJumpTarget:     {"j"},
 
 		inputCaseSensitive: {"alt+c"},
 		inputIncSearch:     {"alt+i"},

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -192,14 +192,14 @@ func (root *Root) rangeToString(x1, y1, x2, y2 int) (string, error) {
 
 	var buff strings.Builder
 
-	ln1 := root.lnumber[y1]
+	ln1 := root.lineNumber(y1)
 	lc1, err := root.Doc.contentsLN(ln1.line, root.Doc.TabWidth)
 	if err != nil {
 		return "", err
 	}
 	wx1 := root.branchWidth(lc1, ln1.wrap)
 
-	ln2 := root.lnumber[y2]
+	ln2 := root.lineNumber(y2)
 	lc2, err := root.Doc.contentsLN(ln2.line, root.Doc.TabWidth)
 	if err != nil {
 		return "", err
@@ -227,7 +227,7 @@ func (root *Root) rangeToString(x1, y1, x2, y2 int) (string, error) {
 
 	lnumber := []int{}
 	for y := y1 + 1; y < y2; y++ {
-		l := root.lnumber[y]
+		l := root.lineNumber(y)
 		if l.line == ln1.line || l.line == ln2.line || l.wrap > 0 {
 			continue
 		}
@@ -256,7 +256,7 @@ func (root *Root) rectangleToString(x1, y1, x2, y2 int) (string, error) {
 	var buff strings.Builder
 
 	for y := y1; y <= y2; y++ {
-		ln := root.lnumber[y]
+		ln := root.lineNumber(y)
 		lc, err := root.Doc.contentsLN(ln.line, root.Doc.TabWidth)
 		if err != nil {
 			return "", err

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -145,6 +145,8 @@ type general struct {
 	SectionDelimiterReg *regexp.Regexp
 	// SectionStartPosition is a section start position.
 	SectionStartPosition int
+	// JumpTarget
+	JumpTarget int
 }
 
 // Config represents the settings of ov.
@@ -171,6 +173,8 @@ type Config struct {
 	StyleSectionLine OVStyle
 	// StyleMultiColorHighlight is the style that applies to the multi color highlight.
 	StyleMultiColorHighlight []OVStyle
+	// StyleJumpTargetLine is the line that displays the search results.
+	StyleJumpTargetLine OVStyle
 
 	// General represents the general behavior.
 	General general
@@ -364,6 +368,9 @@ func NewConfig() Config {
 		StyleSectionLine: OVStyle{
 			Background: "green",
 		},
+		StyleJumpTargetLine: OVStyle{
+			Underline: true,
+		},
 		StyleMultiColorHighlight: []OVStyle{
 			{Foreground: "red"},
 			{Foreground: "aqua"},
@@ -377,6 +384,7 @@ func NewConfig() Config {
 			TabWidth:             8,
 			MarkStyleWidth:       1,
 			SectionStartPosition: 0,
+			JumpTarget:           0,
 		},
 	}
 }

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -801,3 +801,10 @@ func (root *Root) WriteLog() {
 	end := m.BufEndNum()
 	m.Export(os.Stdout, start, end)
 }
+
+func (root *Root) lineNumber(y int) lineNumber {
+	if y >= 0 && y <= len(root.lnumber) {
+		return root.lnumber[y]
+	}
+	return root.lnumber[0]
+}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -145,7 +145,9 @@ type general struct {
 	SectionDelimiterReg *regexp.Regexp
 	// SectionStartPosition is a section start position.
 	SectionStartPosition int
-	// JumpTarget
+	// Specified string for jumpTarget.
+	JumpTargetString string
+	// JumpTarget is the display position of search results.
 	JumpTarget int
 }
 

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -247,7 +247,9 @@ func (root *Root) searchMove(ctx context.Context, forward bool, lN int, searcher
 		if err != nil {
 			return err
 		}
-		root.moveLine(lN - root.Doc.firstLine())
+		root.Doc.topLN = lN - root.Doc.firstLine()
+		root.Doc.topLX = 0
+		root.moveNumUp(root.Doc.JumpTarget)
 		return nil
 	})
 
@@ -284,7 +286,9 @@ func (root *Root) incSearch(ctx context.Context, forward bool) {
 			}
 			return
 		}
-		root.MoveLine(lN - root.Doc.firstLine() + 1)
+		root.Doc.topLN = lN - root.Doc.firstLine()
+		root.Doc.topLX = 0
+		root.moveNumUp(root.Doc.JumpTarget)
 	}()
 }
 

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -39,3 +39,14 @@ func containsInt(list []int, e int) bool {
 	}
 	return false
 }
+
+// toLast toLast moves the specified string to the end.
+func toLast(list []string, s string) []string {
+	if len(s) == 0 {
+		return list
+	}
+
+	list = remove(list, s)
+	list = append(list, s)
+	return list
+}


### PR DESCRIPTION
Added a jump target that shifts the position of search results. Display the search results at the specified position instead of 0 lines.

Added `-j` `--jump-target` option.
Added input key (default j).
Added to be able to set the style (StyleJumpTargetLine) to the corresponding line of jump-taget.

Resolve #220.