### PR TITLE
Make `g` bring us to the top and use `:` to go to a specific line number

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -108,6 +108,7 @@ KeyBind:
         - "Up"
     top:
         - "Home"
+        - "g"
         - "<"
     bottom:
         - "End"
@@ -183,7 +184,7 @@ KeyBind:
     tabwidth:
         - "t"
     goto:
-        - "g"
+        - ":"
     next_search:
         - "n"
     next_backsearch:


### PR DESCRIPTION
With this change ov-less.yaml makes ov act more like less.  `g` was one of the first things I tried.