### PR TITLE
Default to XDG configuration directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,21 +181,24 @@ See the [ov site](https://noborus.github.io/ov/) for more use cases.
 
 ###  3.2. <a name='config'></a>Config
 
-You can set style and key bindings in the setting file.
+You can set style and key bindings in the configuration file.
 
-Create a `.ov.yaml` file in your user's home directory.
-
-for example.
+ov will look for a configuration file in the following paths in descending order:
 
 ```filepath
+$XDG_CONFIG_HOME/ov/config.yaml
+$HOME/.config/ov/config.yaml
 $HOME/.ov.yaml
 ```
 
-Windows.
+On Windows:
 
 ```filepath
+%USERPROFILE%/.config/ov/config.yaml
 %USERPROFILE%/.ov.yaml
 ```
+
+Create a `config.yaml` file in one of the above directories. If the file is in the user home directory, it should be named `.ov.yaml`.
 
 Please refer to the sample [ov.yaml](https://raw.githubusercontent.com/noborus/ov/master/ov.yaml) configuration file.
 
@@ -399,7 +402,7 @@ Flags:
   -d, --column-delimiter string    column delimiter (default ",")
   -c, --column-mode                column mode
       --completion string          generate completion script [bash|zsh|fish|powershell]
-      --config string              config file (default is $HOME/.ov.yaml)
+      --config string              config file (default is $XDG_CONFIG_HOME/ov/config.yaml)
       --debug                      debug mode
       --disable-mouse              disable mouse support
   -e, --exec                       exec command

--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -1,5 +1,5 @@
 # This is a file with less key bindings set.
-# Copy it to ~/.ov.yaml or start it with `ov --config ov-less.yaml`.
+# Copy it to `$XDG_CONFIG_HOME/ov/config.yaml` or start it with `ov --config ov.yaml`.
 # Thanks to hupfdule (Marco Herrn) for the less keybinding information.
 #
 # CaseSensitive: false

--- a/ov.yaml
+++ b/ov.yaml
@@ -1,5 +1,5 @@
 # This is the ov config file.
-# Copy it to ~/.ov.yaml or start it with `ov --config ov.yaml`.
+# Copy it to `$XDG_CONFIG_HOME/ov/config.yaml` or start it with `ov --config ov.yaml`.
 #
 # CaseSensitive: false
 # RegexpSearch: false


### PR DESCRIPTION
This PR implements the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for the configuration file.

If merged, ov will look for the configuration file in the following paths in descending order:

```filepath
$XDG_CONFIG_HOME/ov/config.yaml
$HOME/.config/ov/config.yaml
$HOME/.ov.yaml
```

The original home path is preserved for backwards compatibility, so that users who update the software will not be interrupted by a missing config problem.

