### PR TITLE
Stop resetting top and bottom keys

### DIFF
--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -21,18 +21,12 @@ func (m *Document) moveTop() {
 // Go to the top line.
 // Called from a EventKey.
 func (root *Root) moveTop() {
-	root.resetSelect()
-	defer root.releaseEventBuffer()
-
 	root.Doc.moveTop()
 }
 
 // Go to the bottom line.
 // Called from a EventKey.
 func (root *Root) moveBottom() {
-	root.resetSelect()
-	defer root.releaseEventBuffer()
-
 	root.Doc.topLX, root.Doc.topLN = root.bottomLineNum(root.Doc.BufEndNum())
 }
 


### PR DESCRIPTION
top and bottom do not need to reset keys.
Prevents keys from being reset in `--follow` mode.