### PR TITLE
Enable regular expressions in ColumnDelimiter

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -338,8 +338,7 @@ func (root *Root) setViewMode(modeName string) {
 	}
 
 	root.Doc.general = mergeGeneral(root.Doc.general, c)
-	root.Doc.setSectionDelimiter(root.Doc.SectionDelimiter)
-	root.Doc.setMultiColorWords(root.Doc.MultiColorWords)
+	root.Doc.regexpCompile()
 	root.Doc.ClearCache()
 	root.ViewSync()
 	root.setMessagef("Set mode %s", modeName)
@@ -347,7 +346,7 @@ func (root *Root) setViewMode(modeName string) {
 
 // setDelimiter sets the delimiter string.
 func (root *Root) setDelimiter(input string) {
-	root.Doc.ColumnDelimiter = input
+	root.Doc.setDelimiter(input)
 	root.setMessagef("Set delimiter %s", input)
 }
 

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"regexp"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -333,10 +332,17 @@ func (m *Document) unWatchMode() {
 
 // regexpCompile compiles the new document's regular expressions.
 func (m *Document) regexpCompile() {
+	m.ColumnDelimiterReg = condRegexpCompile(m.ColumnDelimiter)
 	m.setSectionDelimiter(m.SectionDelimiter)
 	if m.MultiColorWords != nil {
 		m.setMultiColorWords(m.MultiColorWords)
 	}
+}
+
+// setDelimiter sets the delimiter string.
+func (m *Document) setDelimiter(delm string) {
+	m.ColumnDelimiter = delm
+	m.ColumnDelimiterReg = condRegexpCompile(delm)
 }
 
 // setSectionDelimiter sets the document section delimiter.
@@ -347,13 +353,5 @@ func (m *Document) setSectionDelimiter(delm string) {
 
 // setMultiColorWords set multiple strings to highlight with multiple colors.
 func (m *Document) setMultiColorWords(words []string) {
-	regexps := make([]*regexp.Regexp, len(words))
-	for n, w := range words {
-		s, err := strconv.Unquote(w)
-		if err != nil {
-			s = w
-		}
-		regexps[n] = regexpCompile(s, true)
-	}
-	m.multiColorRegexps = regexps
+	m.multiColorRegexps = multiRegexpCompile(words)
 }

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -273,10 +273,9 @@ func (root *Root) columnHighlight(lc contents, str string, posCV map[int]int) {
 	}
 
 	numC := len(root.StyleColumnRainbow)
-	delm := m.ColumnDelimiter
 	c := 0
 	start := 0
-	idxs := allIndex(str, delm)
+	idxs := allIndex(str, m.ColumnDelimiter, m.ColumnDelimiterReg)
 	for _, idx := range idxs {
 		if m.ColumnRainbow {
 			RangeStyle(lc, posCV[start], posCV[idx[0]], root.StyleColumnRainbow[c%numC])

--- a/oviewer/input_delimiter.go
+++ b/oviewer/input_delimiter.go
@@ -18,6 +18,7 @@ func delimiterCandidate() *candidate {
 			"\t",
 			"|",
 			",",
+			`/\s+/`,
 		},
 	}
 }

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -405,7 +405,7 @@ func (root *Root) columnX(cursor int) (int, error) {
 			continue
 		}
 		lineStr, posCV := ContentsToStr(lc)
-		idxs := allIndex(lineStr, m.ColumnDelimiter)
+		idxs := allIndex(lineStr, m.ColumnDelimiter, m.ColumnDelimiterReg)
 		maxCursor = max(maxCursor, len(idxs))
 		if len(idxs) < cursor {
 			continue

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -129,6 +129,8 @@ type general struct {
 	WrapMode bool
 	// ColumnDelimiter is a column delimiter.
 	ColumnDelimiter string
+	// ColumnDelimiterReg is a compiled regular expression of ColumnDelimiter.
+	ColumnDelimiterReg *regexp.Regexp
 	// FollowMode is the follow mode.
 	FollowMode bool
 	// FollowAll is a follow mode for all documents.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"code.rocketnine.space/tslocum/cbind"
@@ -113,6 +114,36 @@ func regexpCompile(r string, caseSensitive bool) *regexp.Regexp {
 	return re
 }
 
+// multiRegexpCompile compiles multi-word regular expressions.
+func multiRegexpCompile(words []string) []*regexp.Regexp {
+	regexps := make([]*regexp.Regexp, len(words))
+	for n, w := range words {
+		s, err := strconv.Unquote(w)
+		if err != nil {
+			s = w
+		}
+		regexps[n] = regexpCompile(s, true)
+	}
+	return regexps
+}
+
+// condRegexpCompile conditionally compiles a regular expression.
+func condRegexpCompile(in string) *regexp.Regexp {
+	if len(in) < 2 {
+		return nil
+	}
+
+	if in[0] != '/' || in[len(in)-1] != '/' {
+		return nil
+	}
+
+	re, err := regexp.Compile(in[1 : len(in)-1])
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
 // searchPosition returns the position where the search in the argument line matched.
 // searchPosition uses cache.
 func (root *Root) searchPosition(lN int, lineStr string) [][]int {
@@ -168,7 +199,7 @@ func searchPositionStr(caseSensitive bool, s string, substr string) [][]int {
 		s = strings.ToLower(s)
 		substr = strings.ToLower(substr)
 	}
-	return allIndex(s, substr)
+	return allStringIndex(s, substr)
 }
 
 // setSearcher is a wrapper for NewSearcher and returns a Searcher interface.

--- a/oviewer/search_test.go
+++ b/oviewer/search_test.go
@@ -511,3 +511,100 @@ func TestRoot_setSearch(t *testing.T) {
 		})
 	}
 }
+
+func Test_multiRegexpCompile(t *testing.T) {
+	type args struct {
+		words []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*regexp.Regexp
+	}{
+		{
+			name: "test1",
+			args: args{
+				[]string{".", "["},
+			},
+			want: []*regexp.Regexp{
+				regexp.MustCompile("."),
+				regexp.MustCompile(`\[`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := multiRegexpCompile(tt.args.words); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("multiRegexpCompile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_condRegexpCompile(t *testing.T) {
+	type args struct {
+		in string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *regexp.Regexp
+	}{
+		{
+			name: "testRegexpCompile",
+			args: args{
+				in: "/[,|;]/",
+			},
+			want: regexp.MustCompile(`[,|;]`),
+		},
+		{
+			name: "testString1",
+			args: args{
+				in: ",",
+			},
+			want: nil,
+		},
+		{
+			name: "testString2",
+			args: args{
+				in: "/",
+			},
+			want: nil,
+		},
+		{
+			name: "testString4",
+			args: args{
+				in: "/end",
+			},
+			want: nil,
+		},
+		{
+			name: "testString5",
+			args: args{
+				in: "s/e",
+			},
+			want: nil,
+		},
+		{
+			name: "testString6",
+			args: args{
+				in: `\/\/`,
+			},
+			want: nil,
+		},
+		{
+			name: "testString7",
+			args: args{
+				in: `//`,
+			},
+			want: regexp.MustCompile(``),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := condRegexpCompile(tt.args.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("condRegexpCompile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"regexp"
 	"strings"
 
 	"golang.org/x/exp/constraints"
@@ -75,8 +76,16 @@ func toLast(list []string, s string) []string {
 	return list
 }
 
-// allIndex returns all matching string positions.
-func allIndex(s string, substr string) [][]int {
+// allIndex is a wrapper that returns either a regular expression index or a string index.
+func allIndex(s string, substr string, reg *regexp.Regexp) [][]int {
+	if reg != nil {
+		return reg.FindAllStringIndex(s, -1)
+	}
+	return allStringIndex(s, substr)
+}
+
+// allStringIndex returns all matching string positions.
+func allStringIndex(s string, substr string) [][]int {
 	if len(substr) == 0 {
 		return nil
 	}

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -189,7 +190,7 @@ func Test_containsInt(t *testing.T) {
 	}
 }
 
-func Test_toTop(t *testing.T) {
+func Test_toAddTop(t *testing.T) {
 	type args struct {
 		list []string
 		s    string
@@ -215,11 +216,80 @@ func Test_toTop(t *testing.T) {
 			},
 			want: []string{"f"},
 		},
+		{
+			name: "testNoAdd",
+			args: args{
+				list: []string{"a", "b", "c"},
+				s:    "",
+			},
+			want: []string{"a", "b", "c"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := toAddTop(tt.args.list, tt.args.s); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("toTop() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toAddLast(t *testing.T) {
+	type args struct {
+		list []string
+		s    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "test1",
+			args: args{
+				list: []string{
+					"a",
+				},
+				s: "b",
+			},
+			want: []string{
+				"a",
+				"b",
+			},
+		},
+		{
+			name: "test2",
+			args: args{
+				list: []string{
+					"a",
+					"b",
+				},
+				s: "a",
+			},
+			want: []string{
+				"a",
+				"b",
+			},
+		},
+		{
+			name: "testNoAdd",
+			args: args{
+				list: []string{
+					"a",
+					"b",
+				},
+				s: "",
+			},
+			want: []string{
+				"a",
+				"b",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toAddLast(tt.args.list, tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toAddLast() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -269,7 +339,84 @@ func Test_toLast(t *testing.T) {
 	}
 }
 
+func Test_remove(t *testing.T) {
+	type args struct {
+		list []string
+		s    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "test1",
+			args: args{
+				list: []string{
+					"a",
+				},
+				s: "b",
+			},
+			want: []string{
+				"a",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remove(tt.args.list, tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("remove() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_allIndex(t *testing.T) {
+	type args struct {
+		s      string
+		substr string
+		reg    *regexp.Regexp
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]int
+	}{
+		{
+			name: "test1",
+			args: args{
+				s:      "a,b,c",
+				substr: ",",
+				reg:    nil,
+			},
+			want: [][]int{
+				{1, 2},
+				{3, 4},
+			},
+		},
+		{
+			name: "testRegex",
+			args: args{
+				s:      "a  b c",
+				substr: `/\s+/`,
+				reg:    regexp.MustCompile(`\s+`),
+			},
+			want: [][]int{
+				{1, 3},
+				{4, 5},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allIndex(tt.args.s, tt.args.substr, tt.args.reg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_allStringIndex(t *testing.T) {
 	type args struct {
 		s      string
 		substr string
@@ -309,40 +456,8 @@ func Test_allIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := allIndex(tt.args.s, tt.args.substr); !reflect.DeepEqual(got, tt.want) {
+			if got := allStringIndex(tt.args.s, tt.args.substr); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("allIndex() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_remove(t *testing.T) {
-	type args struct {
-		list []string
-		s    string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "test1",
-			args: args{
-				list: []string{
-					"a",
-				},
-				s: "b",
-			},
-			want: []string{
-				"a",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := remove(tt.args.list, tt.args.s); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("remove() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
A string enclosed by `/` and `/` in ColumnDelimiter is interpreted as a regular expression.
For example, write regular expressions like /[,|;]/ and /\s+/. If the condition is not met, it will be interpreted as a string.

Resolve #251