### PR TITLE
Supports BEL (\a) characters

### DIFF
--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -220,6 +220,9 @@ func (es *parseState) parseEscapeSequence(mainc rune) bool {
 			// unknown but for compatibility.
 			es.state = ansiControlSequence
 			return true
+		case 0x07:
+			es.state = ansiText
+			return true
 		}
 		log.Printf("invalid char %c", mainc)
 		return true
@@ -244,13 +247,19 @@ func (es *parseState) parseEscapeSequence(mainc rune) bool {
 		es.state = oscURL
 		return true
 	case oscURL:
-		if mainc != 0x1b {
-			es.url.WriteRune(mainc)
+		switch mainc {
+		case 0x1b:
+			es.style = es.style.Url(es.url.String())
+			es.url.Reset()
+			es.state = systemSequence
+			return true
+		case 0x07:
+			es.style = es.style.Url(es.url.String())
+			es.url.Reset()
+			es.state = ansiText
 			return true
 		}
-		es.style = es.style.Url(es.url.String())
-		es.url.Reset()
-		es.state = systemSequence
+		es.url.WriteRune(mainc)
 		return true
 	}
 	switch mainc {

--- a/oviewer/content_test.go
+++ b/oviewer/content_test.go
@@ -533,6 +533,16 @@ func Test_parseStringHyperlink(t *testing.T) {
 				{width: 1, style: tcell.StyleDefault.Url("http://example.com").UrlId("1"), mainc: rune('k'), combc: nil},
 			},
 		},
+		{
+			name: "testHyperLinkfile",
+			args: args{line: "\x1b]8;;file:///file\afile\x1b]8;;\a", tabWidth: 8},
+			want: contents{
+				{width: 1, style: tcell.StyleDefault.Url("file:///file"), mainc: rune('f'), combc: nil},
+				{width: 1, style: tcell.StyleDefault.Url("file:///file"), mainc: rune('i'), combc: nil},
+				{width: 1, style: tcell.StyleDefault.Url("file:///file"), mainc: rune('l'), combc: nil},
+				{width: 1, style: tcell.StyleDefault.Url("file:///file"), mainc: rune('e'), combc: nil},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
BEL (\a) characters are used instead of \x1b\\ at the end of the URL.