### PR TITLE
Major changes in memory usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/gdamore/tcell/v2 v2.6.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jwalton/gchalk v1.3.0
-	github.com/klauspost/compress v1.16.0
+	github.com/klauspost/compress v1.16.3
 	github.com/mattn/go-runewidth v0.0.14
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/rivo/uniseg v0.4.4
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/ulikunitz/xz v0.5.11
-	golang.org/x/exp v0.0.0-20230304125523-9ff063c70017
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.6.0
 )
@@ -31,7 +31,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	github.com/spf13/afero v1.9.4 // indirect
+	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/jwalton/gchalk v1.3.0/go.mod h1:ytRlj60R9f7r53IAElbpq4lVuPOPNg2J4tJcC
 github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
 github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
-github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
@@ -180,8 +180,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/afero v1.9.4 h1:Sd43wM1IWz/s1aVXdOBkjJvuP8UdyqioeE4AmM0QsBs=
-github.com/spf13/afero v1.9.4/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
+github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
+github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
@@ -225,7 +225,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -236,8 +236,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230304125523-9ff063c70017 h1:3Ea9SZLCB0aRIhSEjM+iaGIlzzeDJdpi579El/YIhEE=
-golang.org/x/exp v0.0.0-20230304125523-9ff063c70017/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -293,6 +293,7 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -350,6 +351,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309040221-94ec62e08169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -373,6 +375,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=

--- a/main.go
+++ b/main.go
@@ -265,6 +265,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("follow-section", "", false, "follow section")
 	_ = viper.BindPFlag("general.FollowSection", rootCmd.PersistentFlags().Lookup("follow-section"))
 
+	rootCmd.PersistentFlags().BoolP("follow-name", "", false, "follow name mode")
+	_ = viper.BindPFlag("general.FollowName", rootCmd.PersistentFlags().Lookup("follow-name"))
+
 	rootCmd.PersistentFlags().IntP("watch", "T", 0, "watch mode interval")
 	_ = viper.BindPFlag("general.WatchInterval", rootCmd.PersistentFlags().Lookup("watch"))
 

--- a/main.go
+++ b/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/noborus/ov/oviewer"
@@ -142,23 +140,14 @@ func ExecCommand(args []string) error {
 	if len(args) == 0 {
 		return ErrNoArgument
 	}
-
-	command := exec.Command(args[0], args[1:]...)
-	ov, err := oviewer.ExecCommand(command)
+	cmd := oviewer.NewCommand(args)
+	ov, err := cmd.Exec()
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		if command == nil || command.Process == nil {
-			return
-		}
-		if err := command.Process.Kill(); err != nil {
-			log.Println(err)
-		}
-		if err := command.Wait(); err != nil {
-			log.Println(err)
-		}
+		cmd.Wait()
 	}()
 
 	ov.SetConfig(config)

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -89,9 +89,7 @@ func (root *Root) closeFile() {
 		root.setMessage("already closed")
 		return
 	}
-	if err := root.Doc.close(); err != nil {
-		log.Printf("closeFile: %s", err)
-	}
+	root.Doc.closeControl()
 	root.setMessagef("close file %s", root.Doc.FileName)
 	log.Printf("close file %s", root.Doc.FileName)
 }

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -67,6 +67,11 @@ func (root *Root) toggleFollowMode() {
 // toggleFollowAll toggles follow all mode.
 func (root *Root) toggleFollowAll() {
 	root.General.FollowAll = !root.General.FollowAll
+	root.mu.Lock()
+	for _, doc := range root.DocList {
+		doc.latestNum = doc.BufEndNum()
+	}
+	root.mu.Unlock()
 }
 
 // toggleFollowSection toggles follow section mode.
@@ -98,10 +103,12 @@ func (root *Root) reload(m *Document) {
 		return
 	}
 
+	root.mu.Lock()
 	if err := m.reload(); err != nil {
 		log.Printf("cannot reload: %s", err)
 		return
 	}
+	root.mu.Unlock()
 	root.releaseEventBuffer()
 	// Reserve time to read.
 	time.Sleep(100 * time.Millisecond)

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -89,6 +89,10 @@ func (root *Root) closeFile() {
 		root.setMessage("already closed")
 		return
 	}
+	if root.Doc.seekable {
+		root.setMessage("cannnot close")
+		return
+	}
 	root.Doc.closeControl()
 	root.setMessagef("close file %s", root.Doc.FileName)
 	log.Printf("close file %s", root.Doc.FileName)

--- a/oviewer/doclist.go
+++ b/oviewer/doclist.go
@@ -50,9 +50,7 @@ func (root *Root) closeDocument() {
 	root.setMessagef("close [%d]%s", root.CurrentDoc, root.Doc.FileName)
 	log.Printf("close [%d]%s", root.CurrentDoc, root.Doc.FileName)
 	root.mu.Lock()
-	if err := root.DocList[root.CurrentDoc].close(); err != nil {
-		log.Printf("%s:%s", root.Doc.FileName, err)
-	}
+	root.DocList[root.CurrentDoc].closeControl()
 	root.DocList = append(root.DocList[:root.CurrentDoc], root.DocList[root.CurrentDoc+1:]...)
 	if root.CurrentDoc > 0 {
 		root.CurrentDoc--

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -187,8 +187,12 @@ func OpenDocument(fileName string) (*Document, error) {
 		m.seekable = false
 	}
 
+	f, err := open(fileName)
+	if err != nil {
+		return nil, err
+	}
 	m.FileName = fileName
-	if err := m.ControlFile(fileName); err != nil {
+	if err := m.ControlFile(f); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -203,7 +207,11 @@ func STDINDocument() (*Document, error) {
 
 	m.seekable = false
 	m.Caption = "(STDIN)"
-	if err := m.ControlFile(""); err != nil {
+	f, err := open("")
+	if err != nil {
+		return nil, err
+	}
+	if err := m.ControlFile(f); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -221,7 +221,7 @@ func (m *Document) GetLine(n int) string {
 	}
 	chunk := m.chunks[chunkNum]
 
-	if len(chunk.lines) == 0 {
+	if len(chunk.lines) == 0 && atomic.LoadInt32(&m.closed) == 0 {
 		m.loadControl(chunkNum)
 	}
 

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -134,7 +134,7 @@ func NewDocument() (*Document, error) {
 			MarkStyleWidth:  1,
 			PlainMode:       false,
 		},
-		ctlCh:         make(chan controlSpecifier, 10),
+		ctlCh:         make(chan controlSpecifier),
 		seekable:      true,
 		preventReload: false,
 		chunks: []*chunk{

--- a/oviewer/document_test.go
+++ b/oviewer/document_test.go
@@ -82,7 +82,8 @@ func TestDocument_lineToContents(t *testing.T) {
 			if err := m.ReadAll(bytes.NewBufferString(tt.str)); err != nil {
 				t.Fatal(err)
 			}
-			<-m.eofCh
+			for !m.BufEOF() {
+			}
 			t.Logf("num:%d", m.BufEndNum())
 			got, err := m.contents(tt.args.lN, tt.args.tabWidth)
 			if (err != nil) != tt.wantErr {
@@ -136,7 +137,8 @@ func TestDocument_Export(t *testing.T) {
 				t.Fatal(err)
 			}
 			w := &bytes.Buffer{}
-			<-m.eofCh
+			for !m.BufEOF() {
+			}
 			m.bottomLN = m.BufEndNum()
 			m.Export(w, tt.args.start, tt.args.end)
 			if gotW := w.String(); gotW != tt.wantW {

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -383,6 +383,9 @@ func (root *Root) normalLeftStatus() (contents, int) {
 	if root.General.FollowAll {
 		modeStatus = "(Follow All)"
 	}
+	if root.Doc.FollowName {
+		modeStatus = "(Follow Name)"
+	}
 	// Watch mode doubles as FollowSection mode.
 	if root.Doc.WatchMode {
 		modeStatus += "(Watch)"

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -177,9 +177,6 @@ func (root *Root) follow() {
 	if root.General.FollowAll {
 		root.followAll()
 	}
-
-	root.Doc.onceFollowMode()
-
 	num := root.Doc.BufEndNum()
 	if root.Doc.latestNum == num {
 		return
@@ -202,10 +199,8 @@ func (root *Root) followAll() {
 	}
 
 	current := root.CurrentDoc
-
 	root.mu.RLock()
 	for n, doc := range root.DocList {
-		doc.onceFollowMode()
 		if doc.latestNum != doc.BufEndNum() {
 			current = n
 		}
@@ -213,7 +208,6 @@ func (root *Root) followAll() {
 	root.mu.RUnlock()
 
 	if root.CurrentDoc != current {
-		log.Printf("switch document: %d", current)
 		root.switchDocument(current)
 	}
 }

--- a/oviewer/exec.go
+++ b/oviewer/exec.go
@@ -88,8 +88,6 @@ func commandStart(command *exec.Cmd) (io.Reader, io.Reader, error) {
 }
 
 func finishCommand(docout *Document, docerr *Document) {
-	<-docout.eofCh
-	<-docerr.eofCh
 	atomic.StoreInt32(&docout.changed, 1)
 	atomic.StoreInt32(&docerr.changed, 1)
 	atomic.StoreInt32(&docout.closed, 1)

--- a/oviewer/exec.go
+++ b/oviewer/exec.go
@@ -1,14 +1,119 @@
 package oviewer
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/term"
 )
+
+type Command struct {
+	args    []string
+	command *exec.Cmd
+	stdout  io.Reader
+	stderr  io.Reader
+	docout  *Document
+	docerr  *Document
+}
+
+func NewCommand(args []string) *Command {
+	return &Command{
+		args: args,
+	}
+}
+
+func (cmd *Command) Exec() (*Root, error) {
+	cmd.command = exec.Command(cmd.args[0], cmd.args[1:]...)
+	var err error
+	cmd.docout, cmd.docerr, err = newOutErrDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	so, se, err := commandStart(cmd.command)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.stdout = so
+	cmd.stderr = se
+
+	cmd.docout.Caption = "(" + cmd.command.Args[0] + ")" + cmd.docout.FileName
+	atomic.StoreInt32(&cmd.docout.closed, 0)
+	atomic.StoreInt32(&cmd.docerr.closed, 0)
+	err = cmd.docout.ControlReader(so, cmd.Reload)
+	if err != nil {
+		log.Printf("%s", err)
+	}
+	cmd.docerr.Caption = "(" + cmd.command.Args[0] + ")" + cmd.docerr.FileName
+	err = cmd.docerr.ControlReader(se, cmd.stderrReload)
+	if err != nil {
+		log.Printf("%s", err)
+	}
+	return NewOviewer(cmd.docout, cmd.docerr)
+}
+
+func (cmd *Command) Wait() {
+	if cmd.command == nil || cmd.command.Process == nil {
+		return
+	}
+	atomic.StoreInt32(&cmd.docout.closed, 1)
+	atomic.StoreInt32(&cmd.docerr.closed, 1)
+	if err := cmd.command.Process.Kill(); err != nil {
+		log.Println(err)
+	}
+	if err := cmd.command.Wait(); err != nil {
+		log.Println(err)
+	}
+}
+
+func (cmd *Command) Reload() *bufio.Reader {
+	cmd.Wait()
+	if cmd.docout.WatchMode {
+		cmd.docout.appendFormFeed(cmd.docout.lastChunk())
+	} else {
+		cmd.docout.reset()
+	}
+	cmd.command = exec.Command(cmd.args[0], cmd.args[1:]...)
+	so, se, err := commandStart(cmd.command)
+	if err != nil {
+		log.Println(err)
+		str := fmt.Sprintf("command error: %s", err)
+		reader := bufio.NewReader(strings.NewReader(str))
+		return reader
+	}
+	cmd.stdout = so
+	cmd.stderr = se
+
+	sc := controlSpecifier{
+		control: reloadControl,
+		done:    make(chan struct{}),
+	}
+	log.Println("stderr reload send")
+	cmd.docerr.ctlCh <- sc
+	<-sc.done
+	atomic.StoreInt32(&cmd.docerr.readCancel, 0)
+	log.Println("stderr receive done")
+
+	return bufio.NewReader(so)
+}
+
+func (cmd *Command) stderrReload() *bufio.Reader {
+	if !cmd.docout.WatchMode {
+		cmd.docerr.reset()
+	} else {
+		cmd.docerr.appendFormFeed(cmd.docerr.lastChunk())
+	}
+
+	return bufio.NewReader(cmd.stderr)
+}
 
 // ExecCommand return the structure of oviewer.
 // ExecCommand executes the command and opens stdout/stderr as document.
@@ -18,20 +123,18 @@ func ExecCommand(command *exec.Cmd) (*Root, error) {
 		return nil, err
 	}
 
-	go finishCommand(docout, docerr)
-
 	so, se, err := commandStart(command)
 	if err != nil {
 		return nil, err
 	}
 
 	docout.Caption = "(" + command.Args[0] + ")" + docout.FileName
-	err = docout.ReadAll(so)
+	err = docout.ControlReader(so, nil)
 	if err != nil {
 		log.Printf("%s", err)
 	}
 	docerr.Caption = "(" + command.Args[0] + ")" + docerr.FileName
-	err = docerr.ReadAll(se)
+	err = docerr.ControlReader(se, nil)
 	if err != nil {
 		log.Printf("%s", err)
 	}
@@ -44,14 +147,12 @@ func newOutErrDocument() (*Document, *Document, error) {
 		return nil, nil, err
 	}
 	docout.FileName = "STDOUT"
-	docout.preventReload = true
 
 	docerr, err := NewDocument()
 	if err != nil {
 		return nil, nil, err
 	}
 	docerr.FileName = "STDERR"
-	docerr.preventReload = true
 
 	return docout, docerr, nil
 }
@@ -70,7 +171,9 @@ func commandStart(command *exec.Cmd) (io.Reader, io.Reader, error) {
 	if STDOUTPIPE != nil {
 		so = io.TeeReader(so, STDOUTPIPE)
 	}
-
+	if _, err := fmt.Fprintf(command.Stdout, "Time: %s\n", time.Now().Format(time.RFC3339)); err != nil {
+		log.Println(err)
+	}
 	// STDERR
 	errReader, err := command.StderrPipe()
 	if err != nil {
@@ -85,11 +188,4 @@ func commandStart(command *exec.Cmd) (io.Reader, io.Reader, error) {
 		return nil, nil, err
 	}
 	return so, se, nil
-}
-
-func finishCommand(docout *Document, docerr *Document) {
-	atomic.StoreInt32(&docout.changed, 1)
-	atomic.StoreInt32(&docerr.changed, 1)
-	atomic.StoreInt32(&docout.closed, 1)
-	atomic.StoreInt32(&docerr.closed, 1)
 }

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"log"
+	"sync/atomic"
 )
 
 // NewLogDoc generates a document for log.
@@ -15,7 +16,8 @@ func NewLogDoc() (*Document, error) {
 	m.Caption = "Log"
 	m.seekable = false
 	log.SetOutput(m)
-	if err := m.ControlNonFile(); err != nil {
+	atomic.StoreInt32(&m.closed, 1)
+	if err := m.ControlFile(nil); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -12,9 +12,12 @@ func NewLogDoc() (*Document, error) {
 		return nil, err
 	}
 	m.FollowMode = true
-	m.FileName = "Log"
+	m.Caption = "Log"
 	m.seekable = false
 	log.SetOutput(m)
+	if err := m.ControlNonFile(); err != nil {
+		return nil, err
+	}
 	return m, nil
 }
 
@@ -26,6 +29,10 @@ func (m *Document) Write(p []byte) (int, error) {
 	if len(chunk.lines) >= ChunkSize {
 		chunk = NewChunk(m.size)
 		m.mu.Lock()
+		if len(m.chunks) > 2 {
+			m.chunks[len(m.chunks)-2].lines = nil
+			m.startNum = ChunkSize * (len(m.chunks) - 1)
+		}
 		m.chunks = append(m.chunks, chunk)
 		m.mu.Unlock()
 	}

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -17,7 +17,7 @@ func NewLogDoc() (*Document, error) {
 	m.seekable = false
 	log.SetOutput(m)
 	atomic.StoreInt32(&m.closed, 1)
-	if err := m.ControlFile(nil); err != nil {
+	if err := m.ControlLog(); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -15,7 +15,7 @@ func (m *Document) moveLine(lN int) int {
 
 // moveTop moves to the top.
 func (m *Document) moveTop() {
-	m.moveLine(0)
+	m.moveLine(m.startNum)
 }
 
 // Go to the top line.
@@ -58,7 +58,7 @@ func (root *Root) movePgUp() {
 	defer root.releaseEventBuffer()
 
 	root.moveNumUp(root.statusPos - root.headerLen)
-	if root.Doc.topLN < 0 {
+	if root.Doc.topLN < root.Doc.startNum {
 		root.Doc.moveTop()
 	}
 }
@@ -98,7 +98,7 @@ func (root *Root) moveHfUp() {
 	defer root.releaseEventBuffer()
 
 	root.moveNumUp((root.statusPos - root.headerLen) / 2)
-	if root.Doc.topLN < 0 {
+	if root.Doc.topLN < root.Doc.startNum {
 		root.Doc.moveTop()
 	}
 }
@@ -201,7 +201,8 @@ func (root *Root) moveUpN(n int) {
 	defer root.releaseEventBuffer()
 
 	m := root.Doc
-	if m.topLN == 0 && m.topLX == 0 {
+	if m.topLN <= m.startNum && m.topLX == 0 {
+		root.setMessage("Out of bounds")
 		return
 	}
 
@@ -225,8 +226,8 @@ func (root *Root) moveUpN(n int) {
 
 	// Previous line.
 	m.topLN -= n
-	if m.topLN < 0 {
-		m.topLN = 0
+	if m.topLN < m.startNum {
+		m.topLN = m.startNum
 		m.topLX = 0
 		return
 	}
@@ -322,7 +323,7 @@ func (root *Root) prevSection() {
 		return
 	}
 	n = (n - m.firstLine()) + m.SectionStartPosition
-	n = max(n, 0)
+	n = max(n, m.startNum)
 	m.moveLine(n)
 }
 

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -202,7 +202,6 @@ func (root *Root) moveUpN(n int) {
 
 	m := root.Doc
 	if m.topLN <= m.startNum && m.topLX == 0 {
-		root.setMessage("Out of bounds")
 		return
 	}
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -478,9 +478,9 @@ func (root *Root) SetWatcher(watcher *fsnotify.Watcher) {
 						case fsnotify.Write:
 							select {
 							case doc.ctlCh <- controlSpecifier{control: followControl}:
-								log.Printf("notify send %v", event)
+								root.debugMessage(fmt.Sprintf("notify send %v", event))
 							default:
-								log.Println("???", len(doc.ctlCh))
+								root.debugMessage(fmt.Sprintf("notify send fail %d", len(doc.ctlCh)))
 							}
 						case fsnotify.Remove, fsnotify.Create:
 							if !doc.FollowName {
@@ -488,9 +488,9 @@ func (root *Root) SetWatcher(watcher *fsnotify.Watcher) {
 							}
 							select {
 							case doc.ctlCh <- controlSpecifier{control: reloadControl}:
-								log.Printf("notify send %v", event)
+								root.debugMessage(fmt.Sprintf("notify send %v", event))
 							default:
-								log.Println("???", len(doc.ctlCh))
+								root.debugMessage(fmt.Sprintf("notify send fail %d", len(doc.ctlCh)))
 							}
 
 						}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -162,6 +162,8 @@ type general struct {
 	FollowAll bool
 	// FollowSection is a follow mode that uses section instead of line.
 	FollowSection bool
+	// FollowName is the mode to follow files by name.
+	FollowName bool
 	// PlainMode is whether to enable the original character decoration.
 	PlainMode bool
 }
@@ -481,6 +483,9 @@ func (root *Root) SetWatcher(watcher *fsnotify.Watcher) {
 								log.Println("???", len(doc.ctlCh))
 							}
 						case fsnotify.Remove, fsnotify.Create:
+							if !doc.FollowName {
+								continue
+							}
 							select {
 							case doc.ctlCh <- controlSpecifier{control: reloadControl}:
 								log.Printf("notify send %v", event)
@@ -569,6 +574,9 @@ func (root *Root) Run() error {
 		doc.general = root.Config.General
 		doc.regexpCompile()
 
+		if doc.FollowName {
+			doc.FollowMode = true
+		}
 		w := ""
 		if doc.general.WatchInterval > 0 {
 			doc.watchMode()
@@ -770,6 +778,9 @@ func mergeGeneral(src general, dst general) general {
 	}
 	if dst.FollowSection {
 		src.FollowSection = dst.FollowSection
+	}
+	if dst.FollowName {
+		src.FollowName = dst.FollowName
 	}
 	if dst.ColumnDelimiter != "" {
 		src.ColumnDelimiter = dst.ColumnDelimiter

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -63,6 +63,25 @@ func (m *Document) ControlFile(file *os.File) error {
 	return nil
 }
 
+func (m *Document) ControlLog() error {
+	go func() error {
+		for sc := range m.ctlCh {
+			switch sc.control {
+			case reloadControl:
+				m.reset()
+			default:
+				panic(fmt.Sprintf("unexpected %s", sc.control))
+			}
+			if sc.done != nil {
+				close(sc.done)
+			}
+		}
+		log.Println("close m.ctlCh")
+		return nil
+	}()
+	return nil
+}
+
 // controlreader is the controller for io.Reader.
 // Assuming call from Exec. reload executes the argument function.
 func (m *Document) ControlReader(r io.Reader, reload func() *bufio.Reader) error {

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -282,15 +282,16 @@ func (m *Document) readOrCountChunk(chunk *chunk, reader *bufio.Reader, start in
 }
 
 func (m *Document) reloadFile(reader *bufio.Reader) (*bufio.Reader, error) {
-	atomic.StoreInt32(&m.closed, 1)
 	if !m.seekable {
 		m.ClearCache()
 		return reader, nil
 	}
+	atomic.StoreInt32(&m.closed, 1)
 	if err := m.file.Close(); err != nil {
 		log.Printf("reload: %s", err)
 	}
 	m.ClearCache()
+
 	atomic.StoreInt32(&m.closed, 0)
 	atomic.StoreInt32(&m.eof, 0)
 	log.Println("reload", m.FileName)

--- a/oviewer/reader_test.go
+++ b/oviewer/reader_test.go
@@ -160,6 +160,9 @@ func TestDocument_reload(t *testing.T) {
 			m.FileName = tt.fields.FileName
 			m.WatchMode = tt.fields.WatchMode
 			m.seekable = tt.fields.seekable
+			if err := m.ControlFile(tt.fields.FileName); err != nil {
+				t.Fatal("ControlFile error")
+			}
 			if err := m.reload(); (err != nil) != tt.wantErr {
 				t.Errorf("Document.reload() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/oviewer/reader_test.go
+++ b/oviewer/reader_test.go
@@ -160,8 +160,12 @@ func TestDocument_reload(t *testing.T) {
 			m.FileName = tt.fields.FileName
 			m.WatchMode = tt.fields.WatchMode
 			m.seekable = tt.fields.seekable
-			if err := m.ControlFile(tt.fields.FileName); err != nil {
-				t.Fatal("ControlFile error")
+			f, err := open(tt.fields.FileName)
+			if err != nil {
+				t.Fatal("open error", tt.fields.FileName)
+			}
+			if err := m.ControlFile(f); err != nil {
+				t.Fatal("ControlFile error", tt.fields.FileName)
 			}
 			if err := m.reload(); (err != nil) != tt.wantErr {
 				t.Errorf("Document.reload() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Stops storing all read files in memory.
This change applies to regular files only,
not pipes or compressed files.

Change to control by channel to make
it work more asynchronously.

Change File Watch to Directory Watch
to react to file descriptor changes.