### PR TITLE
Fixed EOF on chunk boundaries

### DIFF
--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -390,6 +390,11 @@ func (m *Document) countLines(reader *bufio.Reader, start int) (int, int, error)
 		count += lCount
 		size += lSize
 		if num >= ChunkSize {
+			// no newline at the end of the file.
+			if bufLen < bufSize {
+				p := bytes.LastIndex(buf[:bufLen], []byte("\n"))
+				size -= bufLen - p - 1
+			}
 			break
 		}
 		// no newline at the end of the file.


### PR DESCRIPTION
Fixed some EOF cases without newlines at Chunk boundaries. One line was missing when there was a line without a line break at the end of the chunk.