### PR TITLE
Fixed help search.

### DIFF
--- a/oviewer/help.go
+++ b/oviewer/help.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/jwalton/gchalk"
 )
@@ -28,6 +29,10 @@ func NewHelp(k KeyBind) (*Document, error) {
 	m.preventReload = true
 	m.seekable = false
 	m.setSectionDelimiter("\t")
+	atomic.StoreInt32(&m.closed, 1)
+	if err := m.ControlReader(strings.NewReader(m.FileName), nil); err != nil {
+		return nil, err
+	}
 	return m, err
 }
 


### PR DESCRIPTION
Since requestLoad is required, help also requires ControlReader.