### PR TITLE
quickly move to tail

### DIFF
--- a/oviewer/control_test.go
+++ b/oviewer/control_test.go
@@ -262,6 +262,7 @@ func TestDocument_requestFollow(t *testing.T) {
 			if err != nil {
 				t.Fatal("open error", tt.fields.FileName)
 			}
+			defer f.Close()
 			m.FollowMode = true
 			if err := m.ControlFile(f); err != nil {
 				t.Fatalf("Document.ControlFile() fatal = %v, wantErr %v", err, tt.wantErr)

--- a/oviewer/control_test.go
+++ b/oviewer/control_test.go
@@ -274,7 +274,7 @@ func TestDocument_requestFollow(t *testing.T) {
 			if err != nil {
 				t.Fatal("open error", tt.fields.FileName)
 			}
-
+			defer af.Close()
 			af.Write(tt.fields.appendBytes)
 
 			done := make(chan bool)

--- a/oviewer/control_test.go
+++ b/oviewer/control_test.go
@@ -125,7 +125,7 @@ func TestDocument_requestLoad(t *testing.T) {
 			m.requestLoad(tt.fields.chunkNum)
 
 			chunkNum, cn := chunkLineNum(tt.fields.lineNum)
-			got, err := m.GetChunkLine(chunkNum, cn)
+			got, err := m.store.GetChunkLine(chunkNum, cn)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Document.ControlFile() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/oviewer/doclist.go
+++ b/oviewer/doclist.go
@@ -18,7 +18,7 @@ func (root *Root) hasDocChanged() bool {
 	defer root.mu.RUnlock()
 	eventFlag := false
 	for _, doc := range root.DocList {
-		if atomic.SwapInt32(&doc.changed, 0) == 1 {
+		if atomic.SwapInt32(&doc.store.changed, 0) == 1 {
 			eventFlag = true
 		}
 	}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -259,12 +259,12 @@ func (s *store) GetChunkLine(chunkNum int, cn int) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.chunks) <= chunkNum {
-		return nil, ErrOutOfChunk
+		return nil, fmt.Errorf("over chunk(%d) %w", chunkNum, ErrOutOfRange)
 	}
 	chunk := s.chunks[chunkNum]
 
 	if cn >= len(chunk.lines) {
-		return nil, ErrOutOfRange
+		return nil, fmt.Errorf("over line (%d:%d) %w", chunkNum, cn, ErrOutOfRange)
 	}
 	return chunk.lines[cn], nil
 }

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gdamore/tcell/v2"
 )
@@ -534,6 +535,9 @@ func (root *Root) rightStatus() contents {
 		next = "..."
 	}
 	str := fmt.Sprintf("(%d/%d%s)", root.Doc.topLN, root.Doc.BufEndNum(), next)
+	if atomic.LoadInt32(&root.Doc.tmpFollow) == 1 {
+		str = fmt.Sprintf("(?/%d%s)", root.Doc.storeEndNum(), next)
+	}
 	return StrToContents(str, -1)
 }
 

--- a/oviewer/exec.go
+++ b/oviewer/exec.go
@@ -53,8 +53,8 @@ func (cmd *Command) Exec() (*Root, error) {
 	atomic.StoreInt32(&cmd.docerr.closed, 0)
 	cmd.docout.seekable = false
 	cmd.docerr.seekable = false
-	cmd.docout.formfeedTime = true
-	cmd.docerr.formfeedTime = true
+	cmd.docout.store.formfeedTime = true
+	cmd.docerr.store.formfeedTime = true
 
 	if err = cmd.docout.ControlReader(so, cmd.Reload); err != nil {
 		log.Printf("%s", err)
@@ -89,7 +89,8 @@ func (cmd *Command) Wait() {
 func (cmd *Command) Reload() *bufio.Reader {
 	cmd.Wait()
 	if cmd.docout.WatchMode {
-		cmd.docout.appendFormFeed(cmd.docout.store.chunkForAdd(false, cmd.docout.store.size))
+		s := cmd.docout.store
+		s.appendFormFeed(s.chunkForAdd(false, s.size))
 	} else {
 		cmd.docout.reset()
 	}
@@ -105,7 +106,7 @@ func (cmd *Command) Reload() *bufio.Reader {
 	cmd.stderr = se
 
 	cmd.docerr.requestReload()
-	atomic.StoreInt32(&cmd.docerr.readCancel, 0)
+	atomic.StoreInt32(&cmd.docerr.store.readCancel, 0)
 	log.Println("stderr receive done")
 
 	return bufio.NewReader(so)
@@ -116,7 +117,8 @@ func (cmd *Command) stderrReload() *bufio.Reader {
 	if !cmd.docout.WatchMode {
 		cmd.docerr.reset()
 	} else {
-		cmd.docerr.appendFormFeed(cmd.docerr.store.chunkForAdd(false, cmd.docerr.store.size))
+		s := cmd.docerr.store
+		s.appendFormFeed(s.chunkForAdd(false, s.size))
 	}
 
 	return bufio.NewReader(cmd.stderr)

--- a/oviewer/help.go
+++ b/oviewer/help.go
@@ -17,11 +17,11 @@ func NewHelp(k KeyBind) (*Document, error) {
 		return nil, err
 	}
 
-	m.append(m.store.chunks[m.store.lastChunkNum()], true, []byte("\t\t\t"+gchalk.WithUnderline().Bold("ov help")))
+	m.store.append(m.store.chunks[m.store.lastChunkNum()], true, []byte("\t\t\t"+gchalk.WithUnderline().Bold("ov help")))
 
 	str := strings.Split(KeyBindString(k), "\n")
 	for _, s := range str {
-		m.append(m.store.chunks[m.store.lastChunkNum()], true, []byte(s))
+		m.store.append(m.store.chunks[m.store.lastChunkNum()], true, []byte(s))
 	}
 
 	m.FileName = "Help"

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -26,17 +26,18 @@ func NewLogDoc() (*Document, error) {
 // Write matches the interface of io.Writer(so package log is possible).
 // Therefore, the log.Print output is displayed by logDoc.
 func (m *Document) Write(p []byte) (int, error) {
-	chunk := m.store.chunkForAdd(false, m.store.size)
-	m.append(chunk, true, p)
+	s := m.store
+	chunk := s.chunkForAdd(false, s.size)
+	s.append(chunk, true, p)
 	if len(chunk.lines) >= ChunkSize {
-		chunk = NewChunk(m.store.size)
-		m.store.mu.Lock()
-		if len(m.store.chunks) > 2 {
-			m.store.chunks[len(m.store.chunks)-2].lines = nil
-			atomic.StoreInt32(&m.store.startNum, int32(ChunkSize*(len(m.store.chunks)-1)))
+		chunk = NewChunk(s.size)
+		s.mu.Lock()
+		if len(s.chunks) > 2 {
+			s.chunks[len(s.chunks)-2].lines = nil
+			atomic.StoreInt32(&s.startNum, int32(ChunkSize*(len(s.chunks)-1)))
 		}
-		m.store.chunks = append(m.store.chunks, chunk)
-		m.store.mu.Unlock()
+		s.chunks = append(s.chunks, chunk)
+		s.mu.Unlock()
 	}
 	return len(p), nil
 }

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -2,7 +2,6 @@ package oviewer
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,7 +10,6 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"golang.org/x/term"
 )
@@ -19,6 +17,9 @@ import (
 // bufSize is the size of the buffer used when reading the file.
 // This bufSize is used when only counting.
 const bufSize = 4096
+
+// TailSize represents the position to start reading backwards from the end position.
+const TailSize = 10000
 
 // FormFeed is the delimiter that separates the sections.
 // The default delimiter that separates single output from watch.
@@ -29,7 +30,7 @@ const FormFeed = "\f"
 func (m *Document) firstRead(reader *bufio.Reader) (*bufio.Reader, error) {
 	atomic.StoreInt32(&m.store.noNewlineEOF, 0)
 	chunk := m.store.chunks[0]
-	if err := m.readLines(chunk, reader, 0, ChunkSize, true); err != nil {
+	if err := m.store.readLines(chunk, reader, 0, ChunkSize, true); err != nil {
 		if !errors.Is(err, io.EOF) {
 			atomic.StoreInt32(&m.store.eof, 1)
 			return nil, err
@@ -40,6 +41,29 @@ func (m *Document) firstRead(reader *bufio.Reader) (*bufio.Reader, error) {
 	if !m.BufEOF() {
 		m.requestContinue()
 	}
+	return reader, nil
+}
+
+// tmpFollowRead reads the file in follow-mode.
+// It is executed only once if EOF has not been reached after follow-mode is set.
+func (m *Document) tmpFollowRead(reader *bufio.Reader) (*bufio.Reader, error) {
+	m.followStore = NewStore()
+	atomic.StoreInt32(&m.tmpFollow, 1)
+
+	if ret, err := m.file.Seek(TailSize*-1, io.SeekEnd); err != nil {
+		log.Printf("tmpFollowRead: %d: %v", ret, err)
+		return reader, err
+	}
+	reader.Reset(m.file)
+	chunk := m.followStore.chunks[0]
+	if err := m.followStore.readLines(chunk, reader, 0, ChunkSize, true); err != nil {
+		if !errors.Is(err, io.EOF) {
+			atomic.StoreInt32(&m.followStore.eof, 1)
+			return nil, err
+		}
+	}
+
+	m.requestContinue()
 	return reader, nil
 }
 
@@ -98,7 +122,7 @@ func (m *Document) followRead(reader *bufio.Reader) (*bufio.Reader, error) {
 		reader = bufio.NewReader(m.file)
 	}
 
-	if err := m.readLines(chunk, reader, start, ChunkSize, true); err != nil {
+	if err := m.store.readLines(chunk, reader, start, ChunkSize, true); err != nil {
 		if !errors.Is(err, io.EOF) {
 			return nil, err
 		}
@@ -117,19 +141,19 @@ func (m *Document) addOrReserveChunk(chunk *chunk, reader *bufio.Reader, start i
 	if m.seekable {
 		return m.reserveChunk(reader, start)
 	}
-	return m.readLines(chunk, reader, start, ChunkSize, true)
+	return m.store.readLines(chunk, reader, start, ChunkSize, true)
 }
 
 // reserveChunk reserves ChunkSize lines.
 // read and update size only.
 func (m *Document) reserveChunk(reader *bufio.Reader, start int) error {
-	count, size, err := m.countLines(reader, start)
+	count, size, err := m.store.countLines(reader, start)
 	m.store.mu.Lock()
 	m.store.size += int64(size)
 	m.store.offset = m.store.size
 	m.store.mu.Unlock()
 	atomic.AddInt32(&m.store.endNum, int32(count))
-	atomic.StoreInt32(&m.changed, 1)
+	atomic.StoreInt32(&m.store.changed, 1)
 	return err
 }
 
@@ -141,7 +165,7 @@ func (m *Document) loadChunk(reader *bufio.Reader, chunkNum int) (*bufio.Reader,
 	}
 
 	start, end := m.store.chunkRange(chunkNum)
-	if err := m.readLines(chunk, reader, start, end, false); err != nil {
+	if err := m.store.readLines(chunk, reader, start, end, false); err != nil {
 		if !errors.Is(err, io.EOF) {
 			return nil, err
 		}
@@ -210,7 +234,7 @@ func (m *Document) reloadRead(reader *bufio.Reader) (*bufio.Reader, error) {
 	} else {
 		m.seekable = false
 		chunk := m.store.chunkForAdd(m.seekable, m.store.size)
-		m.appendFormFeed(chunk)
+		m.store.appendFormFeed(chunk)
 	}
 
 	return m.reloadFile(reader)
@@ -245,6 +269,9 @@ func (m *Document) reloadFile(reader *bufio.Reader) (*bufio.Reader, error) {
 func (m *Document) afterEOF(reader *bufio.Reader) *bufio.Reader {
 	m.store.offset = m.store.size
 	atomic.StoreInt32(&m.store.eof, 1)
+	if atomic.SwapInt32(&m.tmpFollow, 0) == 1 {
+		m.cache.Purge()
+	}
 	if !m.seekable { // for NamedPipe.
 		return bufio.NewReader(m.file)
 	}
@@ -305,119 +332,6 @@ func open(fileName string) (*os.File, error) {
 	return f, nil
 }
 
-// readLines append lines read from reader into chunks.
-// Read and fill the number of lines from start to end in chunk.
-// If addLines is true, increment the number of lines read (update endNum).
-func (m *Document) readLines(chunk *chunk, reader *bufio.Reader, start int, end int, updateNum bool) error {
-	var line bytes.Buffer
-	var isPrefix bool
-	for num := start; num < end; {
-		if atomic.LoadInt32(&m.readCancel) == 1 {
-			break
-		}
-		buf, err := reader.ReadSlice('\n')
-		if errors.Is(err, bufio.ErrBufferFull) {
-			isPrefix = true
-			err = nil
-		}
-		line.Write(buf)
-		if isPrefix {
-			isPrefix = false
-			continue
-		}
-
-		num++
-		atomic.StoreInt32(&m.changed, 1)
-		if err != nil {
-			if line.Len() != 0 {
-				m.append(chunk, updateNum, line.Bytes())
-				atomic.StoreInt32(&m.store.noNewlineEOF, 1)
-			}
-			return err
-		}
-		m.append(chunk, updateNum, line.Bytes())
-		line.Reset()
-	}
-	return nil
-}
-
-// countLines counts the number of lines and the size of the buffer.
-func (m *Document) countLines(reader *bufio.Reader, start int) (int, int, error) {
-	num := start
-	count := 0
-	size := 0
-	buf := make([]byte, bufSize)
-	for {
-		bufLen, err := reader.Read(buf)
-		if err != nil {
-			return count, size, fmt.Errorf("read: %w", err)
-		}
-		if bufLen == 0 {
-			return count, size, io.EOF
-		}
-
-		lSize := bufLen
-		lCount := bytes.Count(buf[:bufLen], []byte("\n"))
-		// If it exceeds ChunkSize, Re-aggregate size and count.
-		if num+lCount > ChunkSize {
-			lSize = 0
-			lCount = ChunkSize - num
-			for i := 0; i < lCount; i++ {
-				p := bytes.IndexByte(buf[lSize:bufLen], '\n')
-				lSize += p + 1
-			}
-		}
-
-		num += lCount
-		count += lCount
-		size += lSize
-		if num >= ChunkSize {
-			// no newline at the end of the file.
-			if bufLen < bufSize {
-				p := bytes.LastIndex(buf[:bufLen], []byte("\n"))
-				size -= bufLen - p - 1
-			}
-			break
-		}
-		// no newline at the end of the file.
-		if bufLen < bufSize {
-			p := bytes.LastIndex(buf[:bufLen], []byte("\n"))
-			if p+1 < bufLen {
-				count++
-				atomic.StoreInt32(&m.store.noNewlineEOF, 1)
-			}
-		}
-	}
-	return count, size, nil
-}
-
-// append appends a line to the chunk.
-func (m *Document) append(chunk *chunk, updateNum bool, line []byte) {
-	if updateNum {
-		m.store.appendLine(chunk, line)
-	} else {
-		m.store.appendOnly(chunk, line)
-	}
-	m.store.offset = m.store.size
-}
-
-func (m *Document) appendFormFeed(chunk *chunk) {
-	line := ""
-	m.store.mu.Lock()
-	if len(chunk.lines) > 0 {
-		line = string(chunk.lines[len(chunk.lines)-1])
-	}
-	m.store.mu.Unlock()
-	// Do not add if the previous is FormFeed(always add for formfeedTime).
-	if line != FormFeed {
-		feed := FormFeed
-		if m.formfeedTime {
-			feed = fmt.Sprintf("%sTime: %s", FormFeed, time.Now().Format(time.RFC3339))
-		}
-		m.store.appendLine(chunk, []byte(feed))
-	}
-}
-
 // reload will read again.
 // Regular files are reopened and reread increase.
 // The pipe will reset what it has read.
@@ -431,9 +345,9 @@ func (m *Document) reload() error {
 		return ErrEOFreached
 	}
 
-	atomic.StoreInt32(&m.readCancel, 1)
+	atomic.StoreInt32(&m.store.readCancel, 1)
 	m.requestReload()
-	atomic.StoreInt32(&m.readCancel, 0)
+	atomic.StoreInt32(&m.store.readCancel, 0)
 	if !m.WatchMode {
 		m.topLN = 0
 	}
@@ -445,7 +359,7 @@ func (m *Document) reload() error {
 func (m *Document) reset() {
 	m.store = NewStore()
 	m.store.setNewLoadChunks(m.seekable)
-	atomic.StoreInt32(&m.changed, 1)
+	atomic.StoreInt32(&m.store.changed, 1)
 	m.ClearCache()
 }
 
@@ -466,7 +380,7 @@ func (m *Document) close() error {
 	}
 	atomic.StoreInt32(&m.store.eof, 1)
 	atomic.StoreInt32(&m.closed, 1)
-	atomic.StoreInt32(&m.changed, 1)
+	atomic.StoreInt32(&m.store.changed, 1)
 	return nil
 }
 
@@ -528,7 +442,7 @@ func (m *Document) readAll(reader *bufio.Reader) error {
 	chunk := m.store.chunkForAdd(m.seekable, m.store.size)
 	start := len(chunk.lines)
 	for {
-		if err := m.readLines(chunk, reader, start, ChunkSize, true); err != nil {
+		if err := m.store.readLines(chunk, reader, start, ChunkSize, true); err != nil {
 			return err
 		}
 		chunk = NewChunk(m.store.size)

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -290,7 +290,7 @@ func (m *Document) Search(ctx context.Context, searcher Searcher, chunkNum int, 
 	}
 
 	for n := line; n < ChunkSize; n++ {
-		buf, err := m.GetChunkLine(chunkNum, n)
+		buf, err := m.store.GetChunkLine(chunkNum, n)
 		if err != nil {
 			return n, fmt.Errorf("%w: %d:%d", err, chunkNum, n)
 		}
@@ -313,7 +313,7 @@ func (m *Document) BackSearch(ctx context.Context, searcher Searcher, chunkNum i
 	}
 
 	for n := line; n >= 0; n-- {
-		buf, err := m.GetChunkLine(chunkNum, n)
+		buf, err := m.store.GetChunkLine(chunkNum, n)
 		if err != nil {
 			return n, fmt.Errorf("%w: %d:%d", err, chunkNum, n)
 		}

--- a/oviewer/store.go
+++ b/oviewer/store.go
@@ -231,12 +231,11 @@ func (s *store) readLines(chunk *chunk, reader *bufio.Reader, start int, end int
 }
 
 // countLines counts the number of lines and the size of the buffer.
-func (s *store) countLines(reader *bufio.Reader, start int) (int, int, error) {
-	num := start
+func (s *store) countLines(reader *bufio.Reader, start int, end int) (int, int, error) {
 	count := 0
 	size := 0
 	buf := make([]byte, bufSize)
-	for {
+	for num := start; num < end; {
 		bufLen, err := reader.Read(buf)
 		if err != nil {
 			return count, size, fmt.Errorf("read: %w", err)


### PR DESCRIPTION
If follow-mode is set and EOF is not reached,
set temporary follow-mode.
Temporary follow mode seeks to the end of the file before reading. Then return to normal read.