### PR TITLE
Introduce options for customizing the normal mode's prompt

### DIFF
--- a/ov.yaml
+++ b/ov.yaml
@@ -7,6 +7,8 @@
 # BeforeWriteOriginal: 1000
 # AfterWriteOriginal: 0
 # MemoryLimit: 10000
+# HidePromptFilename: false
+# InvertPromptColor: true
 
 General:
   TabWidth: 8

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -59,5 +59,6 @@ func NewConfig() Config {
 			SectionStartPosition: 0,
 			JumpTarget:           0,
 		},
+		InvertPromptColor: true,
 	}
 }

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -483,20 +483,27 @@ func (root *Root) normalLeftStatus() (contents, int) {
 	} else if root.Doc.FollowSection {
 		modeStatus = "(Follow Section)"
 	}
-	caption := root.Doc.FileName
+
+	caption := ""
 	if root.Doc.Caption != "" {
 		caption = root.Doc.Caption
+	} else if !root.Config.HidePromptFilename {
+		caption = root.Doc.FileName
 	}
 
 	leftStatus := fmt.Sprintf("%s%s%s:%s", number, modeStatus, caption, root.message)
 	leftContents := StrToContents(leftStatus, -1)
-	color := tcell.ColorWhite
-	if root.CurrentDoc != 0 {
-		color = tcell.Color((root.CurrentDoc + 8) % 16)
+
+	if root.Config.InvertPromptColor {
+		color := tcell.ColorWhite
+		if root.CurrentDoc != 0 {
+			color = tcell.Color((root.CurrentDoc + 8) % 16)
+		}
+		for i := 0; i < len(leftContents); i++ {
+			leftContents[i].style = leftContents[i].style.Foreground(tcell.ColorValid + color).Reverse(true)
+		}
 	}
-	for i := 0; i < len(leftContents); i++ {
-		leftContents[i].style = leftContents[i].style.Foreground(tcell.ColorValid + color).Reverse(true)
-	}
+
 	return leftContents, len(leftContents)
 }
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -192,6 +192,8 @@ type Config struct {
 	RegexpSearch             bool
 	Incsearch                bool
 	Debug                    bool
+	HidePromptFilename       bool
+	InvertPromptColor        bool
 }
 
 // OVStyle represents a style in addition to the original style.


### PR DESCRIPTION
First of all, thanks for this great software.

I'd like to have a "Vim-like" minimalistic normal mode prompt without the default filename + background highlighting. I was not able to customize the prompt to my liking with the current options, thus I created two new ones: `HidePromptFilename` and `InvertPromptColor`.

I also thought of organizing all prompt-related options into a single `Config` entry, like this:

```diff
+type OVPromptConfig struct {
+	HideFilename       bool
+	InvertColor        bool
+}
+
 // Config represents the settings of ov.
 type Config struct {
 	Keybind                  map[string][]string
@@ -192,8 +197,7 @@ type Config struct {
 	RegexpSearch             bool
 	Incsearch                bool
 	Debug                    bool
-	HidePromptFilename       bool
-	InvertPromptColor        bool
+	Prompt                   OVPromptConfig
 }
```

What do you think?