### PR TITLE
Changed to trim "\n" for search

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/fs"
@@ -271,7 +272,7 @@ func (s *store) GetChunkLine(chunkNum int, cn int) ([]byte, error) {
 	if cn >= len(chunk.lines) {
 		return nil, fmt.Errorf("over line (%d:%d) %w", chunkNum, cn, ErrOutOfRange)
 	}
-	return chunk.lines[cn], nil
+	return bytes.TrimSuffix(chunk.lines[cn], []byte("\n")), nil
 }
 
 // GetLine returns one line from buffer.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -102,29 +102,30 @@ func (substr sensitiveWord) String() string {
 
 // regexpWord is a regular expression search.
 type regexpWord struct {
-	word *regexp.Regexp
+	word   string
+	regexp *regexp.Regexp
 }
 
 // regexpWord Match is a regular expression search for bytes.
 func (substr regexpWord) Match(s []byte) bool {
 	s = stripEscapeSequenceBytes(s)
-	return substr.word.Match(s)
+	return substr.regexp.Match(s)
 }
 
 // regexpWord MatchString is a regular expression search for string.
 func (substr regexpWord) MatchString(s string) bool {
 	s = stripEscapeSequenceString(s)
-	return substr.word.MatchString(s)
+	return substr.regexp.MatchString(s)
 }
 
 // regexpWord FindAll searches for strings and returns the index of the match.
 func (substr regexpWord) FindAll(s string) [][]int {
-	return substr.word.FindAllStringIndex(s, -1)
+	return substr.regexp.FindAllStringIndex(s, -1)
 }
 
 // regexpWord String returns the search word.
 func (substr regexpWord) String() string {
-	return substr.word.String()
+	return substr.word
 }
 
 // stripRegexpES is a regular expression that excludes escape sequences.
@@ -152,7 +153,8 @@ func stripEscapeSequenceBytes(s []byte) []byte {
 func NewSearcher(word string, searchReg *regexp.Regexp, caseSensitive bool, regexpSearch bool) Searcher {
 	if regexpSearch && word != regexp.QuoteMeta(word) {
 		return regexpWord{
-			word: searchReg,
+			word:   word,
+			regexp: searchReg,
 		}
 	}
 	if caseSensitive {
@@ -173,9 +175,9 @@ func NewSearcher(word string, searchReg *regexp.Regexp, caseSensitive bool, rege
 
 // regexpCompile is regexp.Compile the search string.
 func regexpCompile(r string, caseSensitive bool) *regexp.Regexp {
-	opt := "(?m)"
+	opt := ""
 	if !caseSensitive {
-		opt = "(?mi)"
+		opt = "(?i)"
 	}
 	re, err := regexp.Compile(opt + r)
 	if err == nil {

--- a/oviewer/search_test.go
+++ b/oviewer/search_test.go
@@ -217,7 +217,7 @@ func Test_regexpWord_Match(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			substr := regexpWord{
-				word: tt.fields.word,
+				regexp: tt.fields.word,
 			}
 			if got := substr.MatchString(tt.args.s); got != tt.want {
 				t.Errorf("regexpWord.match() = %v, want %v", got, tt.want)


### PR DESCRIPTION
The (?m) flag doesn't match blank lines (^$),
so the newline code is removed.

The regular expression (?m) flag is unprefixed.

Changed to retain word for regular expression display.