### PR TITLE
Enabled to specify section for jump-target

### DIFF
--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -102,9 +102,10 @@ func Test_jumpPosition(t *testing.T) {
 		str    string
 	}
 	tests := []struct {
-		name string
-		args args
-		want int
+		name  string
+		args  args
+		want  int
+		want1 bool
 	}{
 		{
 			name: "test1",
@@ -112,7 +113,8 @@ func Test_jumpPosition(t *testing.T) {
 				height: 30,
 				str:    "1",
 			},
-			want: 1,
+			want:  1,
+			want1: false,
 		},
 		{
 			name: "test.3",
@@ -120,14 +122,28 @@ func Test_jumpPosition(t *testing.T) {
 				height: 10,
 				str:    ".3",
 			},
-			want: 3,
+			want:  3,
+			want1: false,
+		},
+		{
+			name: "testSection",
+			args: args{
+				height: 30,
+				str:    "s",
+			},
+			want:  0,
+			want1: true,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := jumpPosition(tt.args.height, tt.args.str); got != tt.want {
+			got, got1 := jumpPosition(tt.args.height, tt.args.str)
+			if got != tt.want {
+				t.Errorf("jumpPosition() = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
 				t.Errorf("jumpPosition() = %v, want %v", got, tt.want)
 			}
 		})

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -40,6 +40,89 @@ func TestRoot_toggleColumnMode(t *testing.T) {
 	}
 }
 
+func Test_rangeBA(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		want1   int
+		wantErr bool
+	}{
+		{
+			name: "testInvalid",
+			args: args{
+				str: "invalid",
+			},
+			want:    0,
+			want1:   0,
+			wantErr: true,
+		},
+		{
+			name: "testInvalid2",
+			args: args{
+				str: "1:invalid",
+			},
+			want:    1,
+			want1:   0,
+			wantErr: true,
+		},
+		{
+			name: "testBefore",
+			args: args{
+				str: "1",
+			},
+			want:    1,
+			want1:   0,
+			wantErr: false,
+		},
+		{
+			name: "testBA",
+			args: args{
+				str: "1:1",
+			},
+			want:    1,
+			want1:   1,
+			wantErr: false,
+		},
+		{
+			name: "testOnlyAfter",
+			args: args{
+				str: ":1",
+			},
+			want:    0,
+			want1:   1,
+			wantErr: false,
+		},
+		{
+			name: "testOnlyBefore",
+			args: args{
+				str: "1:",
+			},
+			want:    1,
+			want1:   0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := rangeBA(tt.args.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("rangeBA() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("rangeBA() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("rangeBA() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
 func Test_position(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -123,6 +206,42 @@ func Test_jumpPosition(t *testing.T) {
 				str:    ".3",
 			},
 			want:  3,
+			want1: false,
+		},
+		{
+			name: "testMinus",
+			args: args{
+				height: 30,
+				str:    "-10",
+			},
+			want:  19,
+			want1: false,
+		},
+		{
+			name: "testInvalid",
+			args: args{
+				height: 30,
+				str:    "invalid",
+			},
+			want:  0,
+			want1: false,
+		},
+		{
+			name: "testInvalid2",
+			args: args{
+				height: 30,
+				str:    ".i",
+			},
+			want:  0,
+			want1: false,
+		},
+		{
+			name: "testInvalid3",
+			args: args{
+				height: 30,
+				str:    "p%",
+			},
+			want:  0,
 			want1: false,
 		},
 		{

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -54,10 +54,8 @@ func NewConfig() Config {
 			Underline: true,
 		},
 		General: general{
-			TabWidth:             8,
-			MarkStyleWidth:       1,
-			SectionStartPosition: 0,
-			JumpTarget:           0,
+			TabWidth:       8,
+			MarkStyleWidth: 1,
 		},
 	}
 }

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -68,7 +68,7 @@ func (root *Root) eventLoop(ctx context.Context, quitChan chan<- struct{}) {
 		case *eventNextBackSearch:
 			root.nextBackSearch(ctx, ev.str)
 		case *eventSearchMove:
-			root.searchGoLine(ev.value)
+			root.searchGoto(ev.value)
 		case *eventGoto:
 			root.goLine(ev.value)
 		case *eventHeader:

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -136,6 +136,8 @@ type general struct {
 	SectionStartPosition int
 	// JumpTarget is the display position of search results.
 	JumpTarget int
+	// JumpTargetSection is the display position of search results.
+	JumpTargetSection bool
 	// AlternateRows alternately style rows.
 	AlternateRows bool
 	// ColumnMode is column mode.


### PR DESCRIPTION
Enabled to specify section as well as jump-target value and %.
If `--jump-target section` is specified, it will be displayed from the beginning of the section as much as possible.
The actual jump-target is shown variable.