### PR TITLE
Quickly move to bottom line

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -197,8 +197,9 @@ func (root *Root) searchGoSection(lN int) {
 	root.Doc.topLX = 0
 	y := 0
 
+	width := root.scr.vWidth - root.scr.startX
 	for n := pN; n < lN; n++ {
-		listX := root.leftMostX(n)
+		listX := root.Doc.leftMostX(width, n)
 		y += len(listX)
 	}
 

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -86,6 +86,8 @@ type Document struct {
 
 	// 1 if there is a tmpFollow mode.
 	tmpFollow int32
+	// tmpLN is a temporary line number when the number of lines is undetermined.
+	tmpLN int32
 
 	// WatchMode is watch mode.
 	WatchMode bool

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -266,6 +266,7 @@ func (m *Document) afterEOF(reader *bufio.Reader) *bufio.Reader {
 	m.store.offset = m.store.size
 	atomic.StoreInt32(&m.store.eof, 1)
 	if atomic.SwapInt32(&m.tmpFollow, 0) == 1 {
+		atomic.StoreInt32(&m.tmpLN, atomic.LoadInt32(&m.followStore.endNum))
 		m.cache.Purge()
 	}
 	if !m.seekable { // for NamedPipe.


### PR DESCRIPTION
moveBottom immediately moves to the bottom line.
At the timing of switching from tmpRead,
the number of lines from the bottom line is inherited to the current number of lines.