### PR TITLE
Adjust position only when moving to the beginning

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -113,6 +113,8 @@ type Document struct {
 	seekable bool
 	// Is it possible to reopen.
 	reopenable bool
+	// startTopFlag
+	startTopFlag bool
 }
 
 // store represents store management.
@@ -171,11 +173,12 @@ func NewDocument() (*Document, error) {
 			TabWidth:        8,
 			MarkStyleWidth:  1,
 		},
-		ctlCh:       make(chan controlSpecifier),
-		memoryLimit: 100,
-		seekable:    true,
-		reopenable:  true,
-		store:       NewStore(),
+		ctlCh:        make(chan controlSpecifier),
+		memoryLimit:  100,
+		seekable:     true,
+		reopenable:   true,
+		store:        NewStore(),
+		startTopFlag: true,
 	}
 	if err := m.NewCache(); err != nil {
 		return nil, err

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -38,8 +38,11 @@ func (root *Root) draw() {
 
 	// Section header
 	n := root.drawSectionHeader(lN)
-	if lN == 0 && lN <= root.Doc.SectionHeaderNum {
+	if m.startTopFlag && lN < m.SectionHeaderNum {
 		lN = n
+		m.topLN = n
+	} else {
+		m.startTopFlag = false
 	}
 	// Body
 	lX, lN = root.drawBody(lX, lN)
@@ -117,6 +120,7 @@ func (root *Root) drawSectionHeader(lN int) int {
 	}
 
 	pn := lN
+	// If the line number is 0, it is the first line.
 	if pn == 0 {
 		pn = 1
 	}

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -25,6 +25,7 @@ func (m *Document) moveLine(lN int) int {
 
 // moveTop moves to the top.
 func (m *Document) moveTop() {
+	m.startTopFlag = true
 	m.moveLine(m.BufStartNum())
 }
 


### PR DESCRIPTION
Changed policy to adjust section header movement only when moving to the beginning.