### PR TITLE
Add missing AUR flavours: ov and ov-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ pkg install ov
 
 You can install ov using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
 
-AUR package: [https://aur.archlinux.org/packages/ov-bin](https://aur.archlinux.org/packages/ov-bin)
+Choose an AUR package:
+* [https://aur.archlinux.org/packages/ov](https://aur.archlinux.org/packages/ov) (build and install from latest stable source)
+* [https://aur.archlinux.org/packages/ov-bin](https://aur.archlinux.org/packages/ov-bin) (install pre-compiled binary)
+* [https://aur.archlinux.org/packages/ov-git](https://aur.archlinux.org/packages/ov-git) (build and install from latest git commit)
 
 ###  2.7. <a name='nix-(nixos,-linux,-or-macos)'></a>nix (nixOS, Linux, or macOS)
 


### PR DESCRIPTION
This pull request add two other AUR flavours, `ov` and `ov-git`. If merged, it will close #470.
