### PR TITLE
Added timeout processing for section header search

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -9,7 +10,11 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
+// statusLine is the number of lines in the status bar.
 const statusLine = 1
+
+// sectionTimeOut is the section header search timeout period.
+const sectionTimeOut = 1000
 
 // draw is the main routine that draws the screen.
 func (root *Root) draw() {
@@ -126,6 +131,10 @@ func (root *Root) drawSectionHeader(lN int) int {
 	}
 	sectionLN, err := m.prevSection(pn)
 	if err != nil {
+		if errors.Is(err, ErrCancel) {
+			root.setMessageLogf("Section header search timed out")
+			m.SectionDelimiter = ""
+		}
 		return lN
 	}
 

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"sync/atomic"
+	"time"
 )
 
 // lastLineMargin is the margin of the last line
@@ -297,8 +298,13 @@ func (m *Document) prevSection(n int) (int, error) {
 	lN := n - (1 + m.SectionStartPosition)
 	searcher := NewSearcher(m.SectionDelimiter, m.SectionDelimiterReg, true, true)
 	ctx := context.Background()
-	defer ctx.Done()
-	return m.BackSearchLine(ctx, searcher, lN)
+	ctx, cancel := context.WithTimeout(ctx, sectionTimeOut*time.Millisecond)
+	defer cancel()
+	n, err := m.BackSearchLine(ctx, searcher, lN)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // moveLastSection moves to the last section.


### PR DESCRIPTION
Fixed an issue where the program would freeze
if a section header line was not found in a large file.

Set the search timeout to 1 second and reset the search string if it takes longer.