### PR TITLE
Fix when configuration file is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -506,7 +506,7 @@ func initConfig() {
 		var configNotFoundError *viper.ConfigFileNotFoundError
 		if !errors.As(err, &configNotFoundError) {
 			fmt.Fprintln(os.Stderr, "failed to read config file:", err)
-			return
+			// If the config file is not found, it is not an error and will continue.
 		}
 	}
 


### PR DESCRIPTION
viper.Unmarshal should run even if the configuration file is missing.
This is a fix for #488.