### PR TITLE
Improve README by pointing out where the documentation is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,7 +977,9 @@ The following are not actually pagers and do not conflict. can work together.
 * [bat](https://github.com/sharkdp/bat)
   * `bat` is an alternative to cat. It supports a lot of highlighting and automatically calls the pager.
 * [delta](https://github.com/dandavison/delta)
-  * `delta` processes the diff for easy viewing and displays it. Call the pager automatically.
+  * `delta` processes the diff for easy viewing and displays it. Call the pager automatically. 
+
+Please look at the [documentation portal](https://noborus.github.io/ov/index.html) to configure them.
 
 ##  10. <a name='contributing'></a>Contributing
 


### PR DESCRIPTION
The fact this was missing could cause into a lot of problems and frustration while the information are already available on the website