### PR TITLE
Add filter search and related packages

### DIFF
--- a/biomap/biomap.go
+++ b/biomap/biomap.go
@@ -1,0 +1,59 @@
+package biomap
+
+import "sync"
+
+type Map[k comparable, v comparable] struct {
+	s        sync.RWMutex
+	Forward  map[k]v
+	Backward map[v]k
+}
+
+func NewMap[k comparable, v comparable]() *Map[k, v] {
+	return &Map[k, v]{
+		Forward:  make(map[k]v),
+		Backward: make(map[v]k),
+	}
+}
+
+func (m *Map[k, v]) Store(key k, value v) {
+	m.s.Lock()
+	defer m.s.Unlock()
+	m.Forward[key] = value
+	m.Backward[value] = key
+}
+
+func (m *Map[k, v]) LoadForward(key k) (value v, ok bool) {
+	m.s.RLock()
+	defer m.s.RUnlock()
+	value, ok = m.Forward[key]
+	return
+}
+
+func (m *Map[k, v]) LoadBackward(value v) (key k, ok bool) {
+	m.s.RLock()
+	defer m.s.RUnlock()
+	key, ok = m.Backward[value]
+	return
+}
+
+func (m *Map[k, v]) DeleteForward(key k) {
+	m.s.Lock()
+	defer m.s.Unlock()
+	value, ok := m.Forward[key]
+	if !ok {
+		return
+	}
+	delete(m.Forward, key)
+	delete(m.Backward, value)
+}
+
+func (m *Map[k, v]) DeleteBackward(value v) {
+	m.s.Lock()
+	defer m.s.Unlock()
+	key, ok := m.Backward[value]
+	if !ok {
+		return
+	}
+	delete(m.Forward, key)
+	delete(m.Backward, value)
+}

--- a/biomap/biomap_test.go
+++ b/biomap/biomap_test.go
@@ -1,0 +1,36 @@
+package biomap
+
+import (
+	"testing"
+)
+
+func TestMap(t *testing.T) {
+	m := NewMap[int, string]()
+
+	// Test Store and LoadForward
+	m.Store(1, "one")
+	value, ok := m.LoadForward(1)
+	if !ok || value != "one" {
+		t.Errorf("LoadForward failed. Expected value: %s, got: %s", "one", value)
+	}
+
+	// Test LoadBackward
+	key, ok := m.LoadBackward("one")
+	if !ok || key != 1 {
+		t.Errorf("LoadBackward failed. Expected key: %d, got: %d", 1, key)
+	}
+
+	// Test DeleteForward
+	m.DeleteForward(1)
+	_, ok = m.LoadForward(1)
+	if ok {
+		t.Errorf("DeleteForward failed. Key still exists in Forward map")
+	}
+
+	// Test DeleteBackward
+	m.DeleteBackward("one")
+	_, ok = m.LoadBackward("one")
+	if ok {
+		t.Errorf("DeleteBackward failed. Value still exists in Backward map")
+	}
+}

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -629,6 +629,10 @@ func (root *Root) tailSection() {
 func (root *Root) prepareStartX() {
 	root.scr.startX = 0
 	if root.Doc.LineNumMode {
+		if root.Doc.parent != nil {
+			root.scr.startX = len(fmt.Sprintf("%d", root.Doc.parent.BufEndNum())) + 1
+			return
+		}
 		root.scr.startX = len(fmt.Sprintf("%d", root.Doc.BufEndNum())) + 1
 	}
 }

--- a/oviewer/control.go
+++ b/oviewer/control.go
@@ -176,6 +176,9 @@ func (m *Document) controlReader(sc controlSpecifier, reader *bufio.Reader, relo
 			reader = reload()
 			m.requestStart()
 		}
+	case requestClose:
+		log.Println("close")
+		return reader, nil
 	default:
 		panic(fmt.Sprintf("unexpected %s", sc.request))
 	}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -15,6 +15,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jwalton/gchalk"
 	"github.com/noborus/guesswidth"
+	"github.com/noborus/ov/biomap"
 )
 
 // The Document structure contains the values
@@ -24,6 +25,10 @@ type Document struct {
 	file *os.File
 
 	cache *lru.Cache[int, LineC]
+
+	// parent is the parent document.
+	parent     *Document
+	lineNumMap *biomap.Map[int, int]
 
 	ticker     *time.Ticker
 	tickerDone chan struct{}

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -60,6 +60,8 @@ func (root *Root) eventLoop(ctx context.Context, quitChan chan<- struct{}) {
 			root.nextBackSearch(ctx, ev.str)
 		case *eventSearchMove:
 			root.searchGo(ev.value)
+		case *eventInputFilter:
+			root.filter(ctx)
 		case *eventGoto:
 			root.goLine(ev.value)
 		case *eventHeader:

--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -1,0 +1,78 @@
+package oviewer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+)
+
+func (root *Root) filter(ctx context.Context) {
+	searcher := root.setSearcher(root.input.value, root.Config.CaseSensitive)
+	if searcher == nil {
+		if root.Doc.jumpTargetSection {
+			root.Doc.jumpTargetNum = 0
+		}
+		return
+	}
+	word := root.searcher.String()
+	root.setMessagef("filter:%v (%v)Cancel", word, strings.Join(root.cancelKeys, ","))
+
+	m := root.Doc
+	r, w := io.Pipe()
+	filterDoc, err := renderDoc(m, r)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	filterDoc.FileName = fmt.Sprintf("filter:%s:%v", m.FileName, word)
+	filterDoc.Caption = fmt.Sprintf("%s:%v", m.FileName, word)
+	root.addDocument(filterDoc.Document)
+
+	if m.Header > 0 {
+		for ln := m.SkipLines; ln < m.Header; ln++ {
+			line, err := m.Line(ln)
+			if err != nil {
+				break
+			}
+			filterDoc.lineNumMap.Store(ln, ln)
+			w.Write(line)
+			w.Write([]byte("\n"))
+		}
+	}
+
+	filterDoc.writer = w
+	filterDoc.Header = m.Header
+	filterDoc.SkipLines = m.SkipLines
+
+	go m.searchWriter(ctx, searcher, filterDoc, m.firstLine())
+	root.setMessagef("filter:%v", word)
+}
+
+// searchWriter searches the document and writes the result to w.
+func (m *Document) searchWriter(ctx context.Context, searcher Searcher, renderDoc *renderDocument, ln int) {
+	defer renderDoc.writer.Close()
+	nextLN := ln
+	for {
+		lineNum, err := m.searchLine(ctx, searcher, true, nextLN)
+		if err != nil {
+			break
+		}
+		line, err := m.Line(lineNum)
+		if err != nil {
+			break
+		}
+		num := lineNum
+		if m.lineNumMap != nil {
+			if n, ok := m.lineNumMap.LoadForward(num); ok {
+				num = n
+			}
+		}
+		renderDoc.lineNumMap.Store(ln, num)
+		renderDoc.writer.Write(line)
+		renderDoc.writer.Write([]byte("\n"))
+		nextLN = lineNum + 1
+		ln++
+	}
+}

--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -17,6 +17,7 @@ const (
 	ViewMode                   // ViewMode is a view selection input mode.
 	Search                     // Search is a search input mode.
 	Backsearch                 // Backsearch is a backward search input mode.
+	Filter                     // Filter is a filter input mode.
 	Goline                     // Goline is a move input mode.
 	Header                     // Header is the number of headers input mode.
 	Delimiter                  // Delimiter is a delimiter input mode.

--- a/oviewer/input_search.go
+++ b/oviewer/input_search.go
@@ -135,3 +135,60 @@ func (input *Input) searchCandidates(n int) []string {
 	start := max(0, listLen-n)
 	return input.SearchCandidate.list[start:listLen]
 }
+
+type eventInputFilter struct {
+	tcell.EventTime
+	clist *candidate
+	value string
+}
+
+// setBackSearchMode sets the inputMode to Backsearch.
+func (root *Root) setSearchFilterMode() {
+	input := root.input
+	input.value = ""
+	input.cursorX = 0
+
+	if root.searcher != nil {
+		input.SearchCandidate.toLast(root.searcher.String())
+	}
+
+	input.Event = newSearchFilterEvent(input.SearchCandidate)
+}
+
+func newSearchFilterEvent(clist *candidate) *eventInputFilter {
+	return &eventInputFilter{
+		value:     "",
+		clist:     clist,
+		EventTime: tcell.EventTime{},
+	}
+}
+
+// Mode returns InputMode.
+func (e *eventInputFilter) Mode() InputMode {
+	return Filter
+}
+
+// Prompt returns the prompt string in the input field.
+func (e *eventInputFilter) Prompt() string {
+	return "&"
+}
+
+// Confirm returns the event when the input is confirmed.
+func (e *eventInputFilter) Confirm(str string) tcell.Event {
+	e.value = str
+	e.clist.toLast(str)
+	e.SetEventNow()
+	return e
+}
+
+// Up returns strings when the up key is pressed during input.
+func (e *eventInputFilter) Up(str string) string {
+	e.clist.toAddLast(str)
+	return e.clist.up()
+}
+
+// Down returns strings when the down key is pressed during input.
+func (e *eventInputFilter) Down(str string) string {
+	e.clist.toAddTop(str)
+	return e.clist.down()
+}

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -59,6 +59,7 @@ const (
 	actionAlternate      = "alter_rows_mode"
 	actionLineNumMode    = "line_number_mode"
 	actionSearch         = "search"
+	actionFilter         = "filter"
 	actionWrap           = "wrap_mode"
 	actionColumnMode     = "column_mode"
 	actionColumnWidth    = "column_width"
@@ -143,6 +144,7 @@ func (root *Root) handlers() map[string]func() {
 		actionRemoveAllMark:  root.removeAllMark,
 		actionSearch:         root.setSearchMode,
 		actionBackSearch:     root.setBackSearchMode,
+		actionFilter:         root.setSearchFilterMode,
 		actionDelimiter:      root.setDelimiterMode,
 		actionHeader:         root.setHeaderMode,
 		actionSkipLines:      root.setSkipLinesMode,
@@ -226,6 +228,7 @@ func defaultKeyBinds() KeyBind {
 		actionRemoveMark:     {"M"},
 		actionSearch:         {"/"},
 		actionBackSearch:     {"?"},
+		actionFilter:         {"&"},
 		actionDelimiter:      {"d"},
 		actionHeader:         {"H"},
 		actionSkipLines:      {"ctrl+s"},
@@ -307,6 +310,7 @@ func (k KeyBind) String() string {
 	k.writeKeyBind(&b, actionBackSearch, "backward search mode")
 	k.writeKeyBind(&b, actionNextSearch, "repeat forward search")
 	k.writeKeyBind(&b, actionNextBackSearch, "repeat backward search")
+	k.writeKeyBind(&b, actionFilter, "filter search mode")
 
 	writeHeader(&b, "Change display")
 	k.writeKeyBind(&b, actionWrap, "wrap/nowrap toggle")

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -5,9 +5,13 @@ import (
 	"sync/atomic"
 )
 
+type LogDocument struct {
+	*Document
+}
+
 // NewLogDoc generates a document for log.
 // NewLogDoc makes LogDoc the output destination of go's standard logger.
-func NewLogDoc() (*Document, error) {
+func NewLogDoc() (*LogDocument, error) {
 	m, err := NewDocument()
 	if err != nil {
 		return nil, err
@@ -19,13 +23,16 @@ func NewLogDoc() (*Document, error) {
 	if err := m.ControlLog(); err != nil {
 		return nil, err
 	}
-	log.SetOutput(m)
-	return m, nil
+	l := &LogDocument{
+		Document: m,
+	}
+	log.SetOutput(l)
+	return l, nil
 }
 
 // Write matches the interface of io.Writer(so package log is possible).
 // Therefore, the log.Print output is displayed by logDoc.
-func (m *Document) Write(p []byte) (int, error) {
+func (m *LogDocument) Write(p []byte) (int, error) {
 	s := m.store
 	chunk := s.chunkForAdd(false, s.size)
 	s.append(chunk, true, p)

--- a/oviewer/logdoc_test.go
+++ b/oviewer/logdoc_test.go
@@ -39,12 +39,12 @@ func TestDocument_Write(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, err := NewDocument()
+			l, err := NewLogDoc()
 			if err != nil {
 				t.Fatal(err)
 			}
 			for i := 0; i < tt.repeat; i++ {
-				got, err := m.Write(tt.args.log)
+				got, err := l.Write(tt.args.log)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Document.Write() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -28,7 +28,7 @@ type Root struct {
 	// help
 	helpDoc *Document
 	// log
-	logDoc *Document
+	logDoc *LogDocument
 
 	// input contains the input mode.
 	input *Input
@@ -742,7 +742,7 @@ func (root *Root) debugMessage(msg string) {
 	if !root.Debug {
 		return
 	}
-	if root.Doc == root.logDoc {
+	if root.Doc == root.logDoc.Document {
 		return
 	}
 

--- a/oviewer/render.go
+++ b/oviewer/render.go
@@ -1,0 +1,30 @@
+package oviewer
+
+import (
+	"io"
+
+	"github.com/noborus/ov/biomap"
+)
+
+type renderDocument struct {
+	*Document
+	writer io.WriteCloser
+}
+
+// renderDoc returns a new document with the reader.
+// The reader is rendered and returned as a new document.
+func renderDoc(parent *Document, reader io.Reader) (*renderDocument, error) {
+	doc, err := NewDocument()
+	if err != nil {
+		return nil, err
+	}
+	doc.parent = parent
+	doc.general = mergeGeneral(parent.general, doc.general)
+	doc.lineNumMap = biomap.NewMap[int, int]()
+	doc.preventReload = true
+	doc.seekable = false
+	if err := doc.ControlReader(reader, nil); err != nil {
+		return nil, err
+	}
+	return &renderDocument{Document: doc}, nil
+}


### PR DESCRIPTION
Add filter search feature to search documents by filter. The 'biomap' package, which provides a bidirectional map, is also added to support this feature.

The filter function filters only the lines containing word in the current document and creates a new document.

Link the line numbers of the new document
to the line numbers of the original document.

This implements #493.