### PR TITLE
Add caption options and environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -469,6 +469,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("disable-column-cycle", "", false, "disable column cycling")
 	_ = viper.BindPFlag("DisableColumnCycle", rootCmd.PersistentFlags().Lookup("disable-column-cycle"))
 
+	rootCmd.PersistentFlags().StringP("caption", "", "", "caption")
+	_ = viper.BindPFlag("Caption", rootCmd.PersistentFlags().Lookup("caption"))
+
 	rootCmd.PersistentFlags().BoolP("debug", "", false, "debug mode")
 	_ = viper.BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug"))
 }
@@ -512,6 +515,7 @@ func initConfig() {
 		}
 	}
 
+	viper.SetEnvPrefix("ov")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -255,6 +255,8 @@ type Config struct {
 
 	// DisableColumnCycle is disable column cycle.
 	DisableColumnCycle bool
+	// Caption is the caption of the document.
+	Caption string
 	// Debug represents whether to enable the debug output.
 	Debug bool
 }
@@ -613,6 +615,9 @@ func (root *Root) Run() error {
 	}
 
 	root.optimizedMan()
+	if root.Caption != "" {
+		root.Doc.Caption = root.Caption
+	}
 	root.setModeConfig()
 	for n, doc := range root.DocList {
 		doc.general = root.Config.General


### PR DESCRIPTION
Add option `--caption` to set caption.

Also add the environment variable `OV_CAPTION` to set the caption.

Since we put `viper.SetEnvPrefix("ov")`,
the environment variables must have the `OV_` prefix.

This implements #498 .