### PR TITLE
Fix deep context usage

### DIFF
--- a/examples/search/main.go
+++ b/examples/search/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"sync"
 	"time"
@@ -37,6 +38,6 @@ func main() {
 	ov.Search("import")
 
 	time.Sleep(time.Second * 10)
-	ov.Quit()
+	ov.Quit(context.Background())
 	wg.Wait()
 }

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -14,7 +15,7 @@ import (
 )
 
 // toggleWrapMode toggles wrapMode each time it is called.
-func (root *Root) toggleWrapMode() {
+func (root *Root) toggleWrapMode(context.Context) {
 	m := root.Doc
 	m.WrapMode = !m.WrapMode
 
@@ -32,7 +33,7 @@ func (root *Root) toggleWrapMode() {
 }
 
 // toggleColumnMode toggles ColumnMode each time it is called.
-func (root *Root) toggleColumnMode() {
+func (root *Root) toggleColumnMode(context.Context) {
 	root.Doc.ColumnMode = !root.Doc.ColumnMode
 
 	if root.Doc.ColumnMode {
@@ -42,7 +43,7 @@ func (root *Root) toggleColumnMode() {
 }
 
 // toggleColumnWidth toggles ColumnWidth each time it is called.
-func (root *Root) toggleColumnWidth() {
+func (root *Root) toggleColumnWidth(context.Context) {
 	if root.Doc.ColumnWidth {
 		root.Doc.ColumnWidth = false
 		root.Doc.ColumnMode = false
@@ -55,37 +56,37 @@ func (root *Root) toggleColumnWidth() {
 }
 
 // toggleAlternateRows toggles the AlternateRows each time it is called.
-func (root *Root) toggleAlternateRows() {
+func (root *Root) toggleAlternateRows(context.Context) {
 	root.Doc.AlternateRows = !root.Doc.AlternateRows
 	root.setMessagef("Set AlternateRows %t", root.Doc.AlternateRows)
 }
 
 // toggleLineNumMode toggles LineNumMode every time it is called.
-func (root *Root) toggleLineNumMode() {
+func (root *Root) toggleLineNumMode(ctx context.Context) {
 	root.Doc.LineNumMode = !root.Doc.LineNumMode
-	root.ViewSync()
+	root.ViewSync(ctx)
 	root.setMessagef("Set LineNumMode %t", root.Doc.LineNumMode)
 }
 
 // togglePlain toggles plain mode.
-func (root *Root) togglePlain() {
+func (root *Root) togglePlain(context.Context) {
 	root.Doc.PlainMode = !root.Doc.PlainMode
 	root.setMessagef("Set PlainMode %t", root.Doc.PlainMode)
 }
 
 // togglePlain toggles column rainbow mode.
-func (root *Root) toggleRainbow() {
+func (root *Root) toggleRainbow(context.Context) {
 	root.Doc.ColumnRainbow = !root.Doc.ColumnRainbow
 	root.setMessagef("Set Column Rainbow Mode %t", root.Doc.ColumnRainbow)
 }
 
 // toggleFollowMode toggles follow mode.
-func (root *Root) toggleFollowMode() {
+func (root *Root) toggleFollowMode(context.Context) {
 	root.Doc.FollowMode = !root.Doc.FollowMode
 }
 
 // toggleFollowAll toggles follow all mode.
-func (root *Root) toggleFollowAll() {
+func (root *Root) toggleFollowAll(context.Context) {
 	root.General.FollowAll = !root.General.FollowAll
 	root.mu.Lock()
 	for _, doc := range root.DocList {
@@ -95,12 +96,12 @@ func (root *Root) toggleFollowAll() {
 }
 
 // toggleFollowSection toggles follow section mode.
-func (root *Root) toggleFollowSection() {
+func (root *Root) toggleFollowSection(context.Context) {
 	root.Doc.FollowSection = !root.Doc.FollowSection
 }
 
 // closeFile close the file.
-func (root *Root) closeFile() {
+func (root *Root) closeFile(context.Context) {
 	if root.Doc.documentType == DocHelp || root.Doc.documentType == DocLog {
 		return
 	}
@@ -129,7 +130,7 @@ func (root *Root) reload(m *Document) {
 }
 
 // toggleWatch toggles watch mode.
-func (root *Root) toggleWatch() {
+func (root *Root) toggleWatch(context.Context) {
 	if root.Doc.WatchMode {
 		root.Doc.unWatchMode()
 	} else {
@@ -170,11 +171,11 @@ func (root *Root) watchControl() {
 
 // searchGo will go to the line with the matching term after searching.
 // Jump by section if JumpTargetSection is true.
-func (root *Root) searchGo(lN int) {
+func (root *Root) searchGo(ctx context.Context, lN int) {
 	root.resetSelect()
 	x := root.searchXPos(lN)
 	if root.Doc.jumpTargetSection {
-		root.Doc.searchGoSection(lN, x)
+		root.Doc.searchGoSection(ctx, lN, x)
 		return
 	}
 	root.Doc.searchGoTo(lN, x)
@@ -230,7 +231,7 @@ func (root *Root) goLineNumber(ln int) {
 }
 
 // markNext moves to the next mark.
-func (root *Root) markNext() {
+func (root *Root) markNext(context.Context) {
 	if len(root.Doc.marked) == 0 {
 		return
 	}
@@ -244,7 +245,7 @@ func (root *Root) markNext() {
 }
 
 // markPrev moves to the previous mark.
-func (root *Root) markPrev() {
+func (root *Root) markPrev(context.Context) {
 	if len(root.Doc.marked) == 0 {
 		return
 	}
@@ -258,7 +259,7 @@ func (root *Root) markPrev() {
 }
 
 // addMark marks the current line number.
-func (root *Root) addMark() {
+func (root *Root) addMark(context.Context) {
 	c := min(root.Doc.topLN+root.Doc.firstLine(), root.Doc.BufEndNum())
 	root.Doc.marked = remove(root.Doc.marked, c)
 	root.Doc.marked = append(root.Doc.marked, c)
@@ -266,7 +267,7 @@ func (root *Root) addMark() {
 }
 
 // removeMark removes the current line number from the mark.
-func (root *Root) removeMark() {
+func (root *Root) removeMark(context.Context) {
 	c := root.Doc.topLN + root.Doc.firstLine()
 	marked := remove(root.Doc.marked, c)
 	if len(root.Doc.marked) == len(marked) {
@@ -278,7 +279,7 @@ func (root *Root) removeMark() {
 }
 
 // removeAllMark removes all marks.
-func (root *Root) removeAllMark() {
+func (root *Root) removeAllMark(context.Context) {
 	root.Doc.marked = nil
 	root.Doc.markedPoint = 0
 	root.setMessage("Remove all marks")
@@ -343,7 +344,7 @@ func (root *Root) setSectionNum(input string) {
 
 // suspend suspends the current screen display and runs the shell.
 // It will return when you exit the shell.
-func (root *Root) suspend() {
+func (root *Root) suspend(context.Context) {
 	log.Println("Suspend")
 	if err := root.Screen.Suspend(); err != nil {
 		log.Println(err)
@@ -374,7 +375,7 @@ func (root *Root) suspend() {
 
 // toggleMouse toggles mouse control.
 // When disabled, the mouse is controlled on the terminal side.
-func (root *Root) toggleMouse() {
+func (root *Root) toggleMouse(context.Context) {
 	root.Config.DisableMouse = !root.Config.DisableMouse
 	if root.Config.DisableMouse {
 		root.Screen.DisableMouse()
@@ -387,7 +388,7 @@ func (root *Root) toggleMouse() {
 
 // setViewMode switches to the preset display mode.
 // Set header lines and columnMode together.
-func (root *Root) setViewMode(modeName string) {
+func (root *Root) setViewMode(ctx context.Context, modeName string) {
 	c, ok := root.Config.Mode[modeName]
 	if !ok {
 		if modeName != "general" {
@@ -403,7 +404,7 @@ func (root *Root) setViewMode(modeName string) {
 	}
 	root.Doc.regexpCompile()
 	root.Doc.ClearCache()
-	root.ViewSync()
+	root.ViewSync(ctx)
 	root.setMessagef("Set mode %s", modeName)
 }
 
@@ -452,7 +453,7 @@ func (root *Root) setWatchInterval(input string) {
 
 // setWriteBA sets the number before and after the line
 // to be written at the end.
-func (root *Root) setWriteBA(input string) {
+func (root *Root) setWriteBA(ctx context.Context, input string) {
 	before, after, err := rangeBA(input)
 	if err != nil {
 		root.setMessage(ErrInvalidNumber.Error())
@@ -462,7 +463,7 @@ func (root *Root) setWriteBA(input string) {
 	root.AfterWriteOriginal = after
 	root.debugMessage(fmt.Sprintf("Before:After:%d:%d", root.BeforeWriteOriginal, root.AfterWriteOriginal))
 	root.IsWriteOriginal = true
-	root.Quit()
+	root.Quit(ctx)
 }
 
 // rangeBA returns the before after number from a string.
@@ -545,8 +546,8 @@ func (root *Root) setJumpTarget(input string) {
 }
 
 // resize is a wrapper function that calls viewSync.
-func (root *Root) resize() {
-	root.ViewSync()
+func (root *Root) resize(ctx context.Context) {
+	root.ViewSync(ctx)
 }
 
 // jumpPosition determines the position of the jump.
@@ -603,7 +604,7 @@ func calculatePosition(length int, str string) float64 {
 }
 
 // ViewSync redraws the whole thing.
-func (root *Root) ViewSync() {
+func (root *Root) ViewSync(context.Context) {
 	root.resetSelect()
 	root.prepareStartX()
 	root.prepareView()
@@ -612,16 +613,16 @@ func (root *Root) ViewSync() {
 }
 
 // TailSync move to tail and sync.
-func (root *Root) TailSync() {
+func (root *Root) TailSync(ctx context.Context) {
 	root.Doc.moveBottom()
-	root.ViewSync()
+	root.ViewSync(ctx)
 }
 
 // tailSection moves to the last section
 // and adjusts to its original position.
-func (root *Root) tailSection() {
+func (root *Root) tailSection(ctx context.Context) {
 	moved := root.Doc.topLN - root.Doc.lastSectionPosNum
-	root.Doc.moveLastSection()
+	root.Doc.moveLastSection(ctx)
 	if moved > 0 && (root.Doc.topLN+moved) < root.Doc.BufEndNum() {
 		root.Doc.moveLine(root.Doc.topLN + moved)
 	}
@@ -649,9 +650,9 @@ func (root *Root) updateEndNum() {
 }
 
 // follow updates the document in follow mode.
-func (root *Root) follow() {
+func (root *Root) follow(ctx context.Context) {
 	if root.General.FollowAll {
-		root.followAll()
+		root.followAll(ctx)
 	}
 	num := root.Doc.BufEndNum()
 	if root.Doc.latestNum == num {
@@ -660,16 +661,16 @@ func (root *Root) follow() {
 
 	root.skipDraw = false
 	if root.Doc.FollowSection {
-		root.tailSection()
+		root.tailSection(ctx)
 	} else {
-		root.TailSync()
+		root.TailSync(ctx)
 	}
 	root.Doc.latestNum = num
 }
 
 // followAll monitors and switches all document updates
 // in follow all mode.
-func (root *Root) followAll() {
+func (root *Root) followAll(ctx context.Context) {
 	if root.Doc.documentType != DocNormal {
 		return
 	}
@@ -684,18 +685,18 @@ func (root *Root) followAll() {
 	root.mu.RUnlock()
 
 	if root.CurrentDoc != current {
-		root.switchDocument(current)
+		root.switchDocument(ctx, current)
 	}
 }
 
 // Cancel follow mode and follow all mode.
-func (root *Root) Cancel() {
+func (root *Root) Cancel(context.Context) {
 	root.General.FollowAll = false
 	root.Doc.FollowMode = false
 }
 
 // WriteQuit sets the write flag and executes a quit event.
-func (root *Root) WriteQuit() {
+func (root *Root) WriteQuit(ctx context.Context) {
 	root.IsWriteOriginal = true
-	root.Quit()
+	root.Quit(ctx)
 }

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -32,7 +33,7 @@ func TestRoot_toggleColumnMode(t *testing.T) {
 				t.Fatal(err)
 			}
 			root.Doc.ColumnMode = tt.columnMode
-			root.toggleColumnMode()
+			root.toggleColumnMode(context.Background())
 			if root.Doc.ColumnMode == tt.columnMode {
 				t.Errorf("root.toggleColumnMode() = %v, want %v", root.Doc.ColumnMode, !tt.columnMode)
 			}

--- a/oviewer/benchmark_test.go
+++ b/oviewer/benchmark_test.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,10 +49,13 @@ func Draw_Helper(b *testing.B, fileName string) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	root.ViewSync()
+
+	ctx := context.Background()
+
+	root.ViewSync(ctx)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		root.draw()
+		root.draw(ctx)
 		root.Doc.ClearCache()
 	}
 	root.Close()

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -17,7 +18,7 @@ const statusLine = 1
 const sectionTimeOut = 1000
 
 // draw is the main routine that draws the screen.
-func (root *Root) draw() {
+func (root *Root) draw(ctx context.Context) {
 	m := root.Doc
 
 	if root.scr.vHeight == 0 {
@@ -42,7 +43,7 @@ func (root *Root) draw() {
 	lN = m.topLN + lN
 
 	// Section header
-	n := root.drawSectionHeader(lN)
+	n := root.drawSectionHeader(ctx, lN)
 	if m.dupSectionHeader && lN < m.SectionHeaderNum {
 		lN = n
 		m.topLN = n
@@ -115,7 +116,7 @@ func (root *Root) drawHeader() int {
 // drawSectionHeader draws section header.
 // drawSectionHeader advances the line
 // if the section header contains a line in the terminal.
-func (root *Root) drawSectionHeader(lN int) int {
+func (root *Root) drawSectionHeader(ctx context.Context, lN int) int {
 	m := root.Doc
 	if !m.SectionHeader || m.SectionDelimiter == "" {
 		return lN
@@ -126,7 +127,7 @@ func (root *Root) drawSectionHeader(lN int) int {
 	if m.dupSectionHeader && pn <= 0 {
 		pn = 1
 	}
-	sectionLN, err := m.prevSection(pn)
+	sectionLN, err := m.prevSection(ctx, pn)
 	if err != nil {
 		if errors.Is(err, ErrCancel) {
 			root.setMessageLogf("Section header search timed out")

--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -49,7 +49,7 @@ func (root *Root) filter(ctx context.Context) {
 	render.documentType = DocFilter
 	render.FileName = fmt.Sprintf("filter:%s:%v", m.FileName, word)
 	render.Caption = fmt.Sprintf("%s:%v", m.FileName, word)
-	root.addDocument(render)
+	root.addDocument(ctx, render)
 	render.general = mergeGeneral(m.general, render.general)
 
 	render.nonMatch = m.nonMatch
@@ -105,8 +105,8 @@ func (m *Document) filterWriter(ctx context.Context, searcher Searcher, startLN 
 }
 
 // closeAllFilter closes all filter documents.
-func (root *Root) closeAllFilter() {
-	root.closeAllDocument(DocFilter)
+func (root *Root) closeAllFilter(ctx context.Context) {
+	root.closeAllDocument(ctx, DocFilter)
 }
 
 // writeLine writes a line to w.

--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -186,7 +186,7 @@ func (input *Input) reset() {
 }
 
 // inputCaseSensitive toggles case sensitivity.
-func (root *Root) inputCaseSensitive() {
+func (root *Root) inputCaseSensitive(context.Context) {
 	root.Config.CaseSensitive = !root.Config.CaseSensitive
 	if root.Config.CaseSensitive {
 		root.Config.SmartCaseSensitive = false
@@ -194,7 +194,7 @@ func (root *Root) inputCaseSensitive() {
 }
 
 // inputSmartCaseSensitive toggles case sensitivity.
-func (root *Root) inputSmartCaseSensitive() {
+func (root *Root) inputSmartCaseSensitive(context.Context) {
 	root.Config.SmartCaseSensitive = !root.Config.SmartCaseSensitive
 	if root.Config.SmartCaseSensitive {
 		root.Config.CaseSensitive = false
@@ -202,21 +202,21 @@ func (root *Root) inputSmartCaseSensitive() {
 }
 
 // inputIncSearch toggles incremental search.
-func (root *Root) inputIncSearch() {
+func (root *Root) inputIncSearch(context.Context) {
 	root.Config.Incsearch = !root.Config.Incsearch
 }
 
 // inputRegexpSearch toggles regexp search.
-func (root *Root) inputRegexpSearch() {
+func (root *Root) inputRegexpSearch(context.Context) {
 	root.Config.RegexpSearch = !root.Config.RegexpSearch
 }
 
-func (root *Root) inputNonMatch() {
+func (root *Root) inputNonMatch(context.Context) {
 	root.Doc.nonMatch = !root.Doc.nonMatch
 }
 
 // inputPrevious searches the previous history.
-func (root *Root) inputPrevious() {
+func (root *Root) inputPrevious(context.Context) {
 	input := root.input
 	input.value = input.Event.Up(input.value)
 	runes := []rune(input.value)
@@ -224,7 +224,7 @@ func (root *Root) inputPrevious() {
 }
 
 // inputNext searches the next history.
-func (root *Root) inputNext() {
+func (root *Root) inputNext(context.Context) {
 	input := root.input
 	input.value = input.Event.Down(input.value)
 	runes := []rune(input.value)

--- a/oviewer/input_delimiter.go
+++ b/oviewer/input_delimiter.go
@@ -1,11 +1,13 @@
 package oviewer
 
 import (
+	"context"
+
 	"github.com/gdamore/tcell/v2"
 )
 
 // setDelimiterMode sets the inputMode to Delimiter.
-func (root *Root) setDelimiterMode() {
+func (root *Root) setDelimiterMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.DelimiterCandidate.toLast(root.Doc.ColumnDelimiter)

--- a/oviewer/input_goto.go
+++ b/oviewer/input_goto.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setGoLineMode sets the inputMode to Goline.
-func (root *Root) setGoLineMode() {
+func (root *Root) setGoLineMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newGotoEvent(input.GoCandidate)

--- a/oviewer/input_header.go
+++ b/oviewer/input_header.go
@@ -1,13 +1,14 @@
 package oviewer
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
 )
 
 // setHeaderMode sets the inputMode to Header.
-func (root *Root) setHeaderMode() {
+func (root *Root) setHeaderMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newHeaderEvent()

--- a/oviewer/input_jumptarget.go
+++ b/oviewer/input_jumptarget.go
@@ -1,11 +1,13 @@
 package oviewer
 
 import (
+	"context"
+
 	"github.com/gdamore/tcell/v2"
 )
 
 // setJumpTargetMode sets the inputMode to JumpTarget.
-func (root *Root) setJumpTargetMode() {
+func (root *Root) setJumpTargetMode(context.Context) {
 	input := root.input
 	input.reset()
 

--- a/oviewer/input_multicolor.go
+++ b/oviewer/input_multicolor.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -10,7 +11,7 @@ import (
 const searchCandidateListLen = 10
 
 // setMultiColorMode sets the inputMode to MultiColor.
-func (root *Root) setMultiColorMode() {
+func (root *Root) setMultiColorMode(context.Context) {
 	input := root.input
 	input.reset()
 

--- a/oviewer/input_savebuffer.go
+++ b/oviewer/input_savebuffer.go
@@ -1,18 +1,22 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setSaveBuffer is a wrapper to move to setSaveBufferMode.
-func (root *Root) setSaveBuffer() {
+func (root *Root) setSaveBuffer(ctx context.Context) {
 	if root.Doc.seekable {
 		root.setMessage("Does not support saving regular files")
 		return
 	}
-	root.setSaveBufferMode()
+	root.setSaveBufferMode(ctx)
 }
 
 // setSaveBufferMode sets the inputMode to SaveBuffer.
-func (root *Root) setSaveBufferMode() {
+func (root *Root) setSaveBufferMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newSaveBufferEvent(input.SaveBufferCandidate)

--- a/oviewer/input_search.go
+++ b/oviewer/input_search.go
@@ -1,6 +1,8 @@
 package oviewer
 
 import (
+	"context"
+
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -27,19 +29,19 @@ func (root *Root) setCommonSearchMode() {
 }
 
 // setSearchMode sets the inputMode to Search.
-func (root *Root) setSearchMode() {
+func (root *Root) setSearchMode(context.Context) {
 	root.setCommonSearchMode()
 	root.input.Event = newSearchEvent(root.input.SearchCandidate, forward)
 }
 
 // setBackSearchMode sets the inputMode to Backsearch.
-func (root *Root) setBackSearchMode() {
+func (root *Root) setBackSearchMode(context.Context) {
 	root.setCommonSearchMode()
 	root.input.Event = newSearchEvent(root.input.SearchCandidate, backward)
 }
 
 // setSearchFilterMode sets the inputMode to Filter.
-func (root *Root) setSearchFilterMode() {
+func (root *Root) setSearchFilterMode(context.Context) {
 	root.setCommonSearchMode()
 	root.input.Event = newSearchEvent(root.input.SearchCandidate, filter)
 }

--- a/oviewer/input_section_delimiter.go
+++ b/oviewer/input_section_delimiter.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setSectionDelimiterMode sets the inputMode to SectionDelimiter.
-func (root *Root) setSectionDelimiterMode() {
+func (root *Root) setSectionDelimiterMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.SectionDelmCandidate.toLast(root.Doc.SectionDelimiter)

--- a/oviewer/input_section_num.go
+++ b/oviewer/input_section_num.go
@@ -1,13 +1,14 @@
 package oviewer
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
 )
 
 // setSectionNumMode sets the inputMode to SectionNum.
-func (root *Root) setSectionNumMode() {
+func (root *Root) setSectionNumMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newSectionNumEvent()

--- a/oviewer/input_section_start.go
+++ b/oviewer/input_section_start.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setSectionStartMode sets the inputMode to SectionStart.
-func (root *Root) setSectionStartMode() {
+func (root *Root) setSectionStartMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newSectionStartEvent(input.SectionStartCandidate)

--- a/oviewer/input_skip.go
+++ b/oviewer/input_skip.go
@@ -1,13 +1,14 @@
 package oviewer
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
 )
 
 // setSkipLinesMode sets the inputMode to SkipLines.
-func (root *Root) setSkipLinesMode() {
+func (root *Root) setSkipLinesMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newSkipLinesEvent()

--- a/oviewer/input_tabwidth.go
+++ b/oviewer/input_tabwidth.go
@@ -1,13 +1,14 @@
 package oviewer
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
 )
 
 // setTabWidthMode sets the inputMode to TabWidth.
-func (root *Root) setTabWidthMode() {
+func (root *Root) setTabWidthMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.TabWidthCandidate.toLast(strconv.Itoa(root.Doc.TabWidth))

--- a/oviewer/input_viewmode.go
+++ b/oviewer/input_viewmode.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setViewModeMode sets the inputMode to ViewMode.
-func (root *Root) setViewInputMode() {
+func (root *Root) setViewInputMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newViewModeEvent(input.ModeCandidate)

--- a/oviewer/input_watch.go
+++ b/oviewer/input_watch.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setWatchIntervalMode sets the inputMode to Watch.
-func (root *Root) setWatchIntervalMode() {
+func (root *Root) setWatchIntervalMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newWatchIntervalEvent(input.WatchCandidate)

--- a/oviewer/input_writeba.go
+++ b/oviewer/input_writeba.go
@@ -1,9 +1,13 @@
 package oviewer
 
-import "github.com/gdamore/tcell/v2"
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 // setWriteBAMode sets the inputMode to WriteBA.
-func (root *Root) setWriteBAMode() {
+func (root *Root) setWriteBAMode(context.Context) {
 	input := root.input
 	input.reset()
 	input.Event = newWriteBAEvent(input.WriteBACandidate)

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -15,7 +15,7 @@ import (
 var WheelScrollNum = 2
 
 // mouseEvent handles mouse events.
-func (root *Root) mouseEvent(ev *tcell.EventMouse) {
+func (root *Root) mouseEvent(ctx context.Context, ev *tcell.EventMouse) {
 	button := ev.Buttons()
 	mod := ev.Modifiers()
 
@@ -26,33 +26,33 @@ func (root *Root) mouseEvent(ev *tcell.EventMouse) {
 
 	if button&tcell.WheelUp != 0 {
 		if horizontal {
-			root.wheelLeft()
+			root.wheelLeft(ctx)
 			return
 		}
-		root.wheelUp()
+		root.wheelUp(ctx)
 		return
 	}
 
 	if button&tcell.WheelDown != 0 {
 		if horizontal {
-			root.wheelRight()
+			root.wheelRight(ctx)
 			return
 		}
-		root.wheelDown()
+		root.wheelDown(ctx)
 		return
 	}
 
 	if button&tcell.WheelLeft != 0 {
-		root.wheelLeft()
+		root.wheelLeft(ctx)
 		return
 	}
 	if button&tcell.WheelRight != 0 {
-		root.wheelRight()
+		root.wheelRight(ctx)
 		return
 	}
 
 	if button != tcell.ButtonNone || root.mouseSelect {
-		root.selectRange(ev)
+		root.selectRange(ctx, ev)
 		return
 	}
 
@@ -61,30 +61,30 @@ func (root *Root) mouseEvent(ev *tcell.EventMouse) {
 }
 
 // wheelUp moves the mouse wheel up.
-func (root *Root) wheelUp() {
+func (root *Root) wheelUp(context.Context) {
 	root.setMessage("")
 	root.moveUp(WheelScrollNum)
 }
 
 // wheelDown moves the mouse wheel down.
-func (root *Root) wheelDown() {
+func (root *Root) wheelDown(context.Context) {
 	root.setMessage("")
 	root.moveDown(WheelScrollNum)
 }
 
-func (root *Root) wheelRight() {
+func (root *Root) wheelRight(ctx context.Context) {
 	root.setMessage("")
 	if root.Doc.ColumnMode {
-		root.moveRightOne()
+		root.moveRightOne(ctx)
 	} else {
 		root.moveRight(root.Doc.HScrollWidthNum)
 	}
 }
 
-func (root *Root) wheelLeft() {
+func (root *Root) wheelLeft(ctx context.Context) {
 	root.setMessage("")
 	if root.Doc.ColumnMode {
-		root.moveLeftOne()
+		root.moveLeftOne(ctx)
 	} else {
 		root.moveLeft(root.Doc.HScrollWidthNum)
 	}
@@ -92,10 +92,10 @@ func (root *Root) wheelLeft() {
 
 // selectRange saves the position by selecting the range with the mouse.
 // The selection range is represented by (x1, y1), (x2, y2).
-func (root *Root) selectRange(ev *tcell.EventMouse) {
+func (root *Root) selectRange(ctx context.Context, ev *tcell.EventMouse) {
 	button := ev.Buttons()
 	if button == tcell.ButtonMiddle {
-		root.Paste()
+		root.Paste(ctx)
 		return
 	}
 
@@ -121,7 +121,7 @@ func (root *Root) selectRange(ev *tcell.EventMouse) {
 		} else if !root.mousePressed {
 			root.resetSelect()
 			if button == tcell.ButtonPrimary || button == tcell.ButtonSecondary {
-				root.CopySelect()
+				root.CopySelect(ctx)
 			}
 		}
 	}
@@ -139,7 +139,7 @@ type eventCopySelect struct {
 }
 
 // CopySelect fires the eventCopySelect event.
-func (root *Root) CopySelect() {
+func (root *Root) CopySelect(context.Context) {
 	root.sendCopySelect()
 }
 
@@ -185,7 +185,7 @@ type eventPaste struct {
 }
 
 // Paste fires the eventPaste event.
-func (root *Root) Paste() {
+func (root *Root) Paste(context.Context) {
 	root.sendPaste()
 }
 
@@ -196,7 +196,7 @@ func (root *Root) sendPaste() {
 }
 
 // pasteFromClipboard writes a string from the clipboard.
-func (root *Root) pasteFromClipboard(_ context.Context) {
+func (root *Root) pasteFromClipboard(context.Context) {
 	input := root.input
 	switch input.Event.Mode() {
 	case Normal:

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -1,12 +1,14 @@
 package oviewer
 
+import "context"
+
 // Called by event key to change document position.
 
 // bottomMargin is the margin of the bottom line when specifying section.
 const bottomMargin = 2
 
 // Go to the top line.
-func (root *Root) moveTop() {
+func (root *Root) moveTop(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -15,7 +17,7 @@ func (root *Root) moveTop() {
 }
 
 // Go to the bottom line.
-func (root *Root) moveBottom() {
+func (root *Root) moveBottom(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -23,7 +25,7 @@ func (root *Root) moveBottom() {
 }
 
 // Move up one screen.
-func (root *Root) movePgUp() {
+func (root *Root) movePgUp(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -31,7 +33,7 @@ func (root *Root) movePgUp() {
 }
 
 // Moves down one screen.
-func (root *Root) movePgDn() {
+func (root *Root) movePgDn(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -39,7 +41,7 @@ func (root *Root) movePgDn() {
 }
 
 // Moves up half a screen.
-func (root *Root) moveHfUp() {
+func (root *Root) moveHfUp(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -47,7 +49,7 @@ func (root *Root) moveHfUp() {
 }
 
 // Moves down half a screen.
-func (root *Root) moveHfDn() {
+func (root *Root) moveHfDn(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -55,12 +57,12 @@ func (root *Root) moveHfDn() {
 }
 
 // Move up one line.
-func (root *Root) moveUpOne() {
+func (root *Root) moveUpOne(context.Context) {
 	root.moveUp(1)
 }
 
 // Move down one line.
-func (root *Root) moveDownOne() {
+func (root *Root) moveDownOne(context.Context) {
 	root.moveDown(1)
 }
 
@@ -81,52 +83,52 @@ func (root *Root) moveDown(n int) {
 }
 
 // nextSection moves down to the next section's delimiter.
-func (root *Root) nextSection() {
+func (root *Root) nextSection(ctx context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	if err := root.Doc.moveNextSection(); err != nil {
+	if err := root.Doc.moveNextSection(ctx); err != nil {
 		// Last section or no section.
 		root.setMessage("No more next sections")
 	}
 }
 
 // prevSection moves up to the delimiter of the previous section.
-func (root *Root) prevSection() {
+func (root *Root) prevSection(ctx context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	if err := root.Doc.movePrevSection(); err != nil {
+	if err := root.Doc.movePrevSection(ctx); err != nil {
 		root.setMessage("No more previous sections")
 		return
 	}
 }
 
 // lastSection moves to the last section.
-func (root *Root) lastSection() {
+func (root *Root) lastSection(ctx context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	root.Doc.moveLastSection()
+	root.Doc.moveLastSection(ctx)
 }
 
 // Move to the left.
-func (root *Root) moveLeftOne() {
+func (root *Root) moveLeftOne(context.Context) {
 	root.moveLeft(1)
 }
 
 // Move to the right.
-func (root *Root) moveRightOne() {
+func (root *Root) moveRightOne(context.Context) {
 	root.moveRight(1)
 }
 
 // Move to the width of the screen to the left.
-func (root *Root) moveWidthLeft() {
+func (root *Root) moveWidthLeft(context.Context) {
 	root.moveLeft(root.Doc.HScrollWidthNum)
 }
 
 // Move to the width of the screen to the right.
-func (root *Root) moveWidthRight() {
+func (root *Root) moveWidthRight(context.Context) {
 	root.moveRight(root.Doc.HScrollWidthNum)
 }
 
@@ -155,7 +157,7 @@ func (root *Root) moveRight(n int) {
 }
 
 // Move to the left by half a screen.
-func (root *Root) moveHfLeft() {
+func (root *Root) moveHfLeft(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -164,7 +166,7 @@ func (root *Root) moveHfLeft() {
 }
 
 // Move to the right by half a screen.
-func (root *Root) moveHfRight() {
+func (root *Root) moveHfRight(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -172,13 +174,13 @@ func (root *Root) moveHfRight() {
 }
 
 // moveBeginLeft moves to the beginning of the line.
-func (root *Root) moveBeginLeft() {
+func (root *Root) moveBeginLeft(context.Context) {
 	root.Doc.moveBeginLeft()
 }
 
 // moveEndRight moves to the end of the line.
 // Move so that the end of the currently displayed line is visible.
-func (root *Root) moveEndRight() {
+func (root *Root) moveEndRight(context.Context) {
 	root.Doc.moveEndRight(root.scr)
 }
 

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -249,14 +249,14 @@ func leftX(width int, lc contents) []int {
 }
 
 // moveNextSection moves to the next section.
-func (m *Document) moveNextSection() error {
+func (m *Document) moveNextSection(ctx context.Context) error {
 	// Move by page, if there is no section delimiter.
 	if m.SectionDelimiter == "" {
 		m.movePgDn()
 		return nil
 	}
 
-	lN, err := m.nextSection(m.topLN + m.firstLine())
+	lN, err := m.nextSection(ctx, m.topLN+m.firstLine())
 	if err != nil {
 		m.movePgDn()
 		return ErrNoDelimiter
@@ -266,24 +266,21 @@ func (m *Document) moveNextSection() error {
 }
 
 // nextSection returns the line number of the previous section.
-func (m *Document) nextSection(n int) (int, error) {
-	ctx := context.Background()
-	defer ctx.Done()
-
+func (m *Document) nextSection(ctx context.Context, n int) (int, error) {
 	lN := n + (1 - m.SectionStartPosition)
 	searcher := NewSearcher(m.SectionDelimiter, m.SectionDelimiterReg, true, true)
 	return m.SearchLine(ctx, searcher, lN)
 }
 
 // movePrevSection moves to the previous section.
-func (m *Document) movePrevSection() error {
+func (m *Document) movePrevSection(ctx context.Context) error {
 	// Move by page, if there is no section delimiter.
 	if m.SectionDelimiter == "" {
 		m.movePgUp()
 		return nil
 	}
 
-	lN, err := m.prevSection(m.topLN + m.firstLine() - m.SectionHeaderNum)
+	lN, err := m.prevSection(ctx, m.topLN+m.firstLine()-m.SectionHeaderNum)
 	if err != nil {
 		m.moveTop()
 		return err
@@ -295,8 +292,7 @@ func (m *Document) movePrevSection() error {
 }
 
 // prevSection returns the line number of the previous section.
-func (m *Document) prevSection(n int) (int, error) {
-	ctx := context.Background()
+func (m *Document) prevSection(ctx context.Context, n int) (int, error) {
 	ctx, cancel := context.WithTimeout(ctx, sectionTimeOut*time.Millisecond)
 	defer cancel()
 
@@ -306,10 +302,7 @@ func (m *Document) prevSection(n int) (int, error) {
 }
 
 // moveLastSection moves to the last section.
-func (m *Document) moveLastSection() {
-	ctx := context.Background()
-	defer ctx.Done()
-
+func (m *Document) moveLastSection(ctx context.Context) {
 	// +1 to avoid if the bottom line is a session delimiter.
 	lN := m.BufEndNum() - 2
 	searcher := NewSearcher(m.SectionDelimiter, m.SectionDelimiterReg, true, true)

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -2,6 +2,7 @@ package oviewer
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"path/filepath"
 	"reflect"
@@ -106,7 +107,7 @@ func TestOpen(t *testing.T) {
 				t.Errorf("Open() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			root.Quit()
+			root.Quit(context.Background())
 		})
 	}
 }
@@ -194,7 +195,7 @@ func TestRoot_Run(t *testing.T) {
 					t.Errorf("Root.Run() error = %v, wantErr %v", err, tt.wantErr)
 				}
 			}()
-			root.Quit()
+			root.Quit(context.Background())
 		})
 	}
 }
@@ -274,7 +275,7 @@ func TestRoot_setKeyConfig(t *testing.T) {
 				t.Fatal("failed to unmarshal config:", err)
 			}
 			root.SetConfig(config)
-			got, err := root.setKeyConfig()
+			got, err := root.setKeyConfig(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Root.setKeyConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -643,7 +643,7 @@ type eventNextSearch struct {
 }
 
 // sendNextSearch fires the eventNextSearch event.
-func (root *Root) sendNextSearch() {
+func (root *Root) sendNextSearch(context.Context) {
 	if root.searcher == nil {
 		return
 	}
@@ -661,7 +661,7 @@ type eventNextBackSearch struct {
 }
 
 // sendNextBackSearch fires the eventNextBackSearch event.
-func (root *Root) sendNextBackSearch() {
+func (root *Root) sendNextBackSearch(context.Context) {
 	if root.searcher == nil {
 		return
 	}

--- a/oviewer/search_move.go
+++ b/oviewer/search_move.go
@@ -1,5 +1,7 @@
 package oviewer
 
+import "context"
+
 // searchGoTo moves to the specified line and position after searching.
 // Go to the specified line +root.Doc.JumpTarget Go to.
 // If the search term is off screen, move until the search term is visible.
@@ -17,10 +19,10 @@ func (m *Document) bottomJumpTarget() int {
 
 // searchGoSection will go to the section with the matching term after searching.
 // Move the JumpTarget so that it can be seen from the beginning of the section.
-func (m *Document) searchGoSection(lN int, x int) {
+func (m *Document) searchGoSection(ctx context.Context, lN int, x int) {
 	m.searchGoX(x)
 
-	sN, err := m.prevSection(lN)
+	sN, err := m.prevSection(ctx, lN)
 	if err != nil {
 		sN = 0
 	}


### PR DESCRIPTION
A few methods were creating a new context, this is a bad pattern.                                                                                
                                                                                                                                                     
These issues were in oviewer/move_vertical.go for the following methods:                                                                         
- nextSection                                                                                                                                    
- prevSection                                                                                                                                    
                                                                                                                                                     
Because of these 2 functions code had to be refactored to pass `func(context.Context)` everywhere needed.

Fixes #539 539