### PR TITLE
Apply timeout settings at correct locations

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 )
@@ -14,7 +15,7 @@ import (
 // statusLine is the number of lines in the status bar.
 const statusLine = 1
 
-// sectionTimeOut is the section header search timeout period.
+// sectionTimeOut is the section header search timeout(in milliseconds) period.
 const sectionTimeOut = 1000
 
 // draw is the main routine that draws the screen.
@@ -127,6 +128,8 @@ func (root *Root) drawSectionHeader(ctx context.Context, lN int) int {
 	if m.dupSectionHeader && pn <= 0 {
 		pn = 1
 	}
+	ctx, cancel := context.WithTimeout(ctx, sectionTimeOut*time.Millisecond)
+	defer cancel()
 	sectionLN, err := m.prevSection(ctx, pn)
 	if err != nil {
 		if errors.Is(err, ErrCancel) {

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"sync/atomic"
-	"time"
 )
 
 // lastLineMargin is the margin of the last line
@@ -293,12 +292,6 @@ func (m *Document) movePrevSection(ctx context.Context) error {
 
 // prevSection returns the line number of the previous section.
 func (m *Document) prevSection(ctx context.Context, n int) (int, error) {
-	// TODO: Timeout should be specified in the caller instead of here.
-	// If it takes a long time to find the section header,
-	// it will freeze during that time, so a timeout is set.
-	ctx, cancel := context.WithTimeout(ctx, sectionTimeOut*time.Millisecond)
-	defer cancel()
-
 	searcher := NewSearcher(m.SectionDelimiter, m.SectionDelimiterReg, true, true)
 	lN := n - (1 + m.SectionStartPosition)
 	return m.BackSearchLine(ctx, searcher, lN)


### PR DESCRIPTION
The timeout settings were applied at the wrong locations.
Resolves the TODO.