### PR TITLE
Set to fileName instead of caption

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -264,7 +264,7 @@ func STDINDocument() (*Document, error) {
 
 	m.seekable = false
 	m.reopenable = false
-	m.Caption = "(STDIN)"
+	m.FileName = "(STDIN)"
 	f, err := open("")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Set to fileName instead of caption to enable
settings to suppress display.

fix #553