### PR TITLE
Changed the method of implementing section-header

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -203,7 +203,8 @@ func (root *Root) goLine(input string) {
 			root.setMessage(ErrInvalidNumber.Error())
 			return
 		}
-		lN = root.Doc.moveLine(lN - 1)
+		lN = max(0, lN-1)
+		lN = root.Doc.moveLine(lN)
 		root.setMessagef("Moved to line %d", lN+1)
 		return
 	}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -104,6 +104,11 @@ type Document struct {
 	// columnCursor is the number of columns.
 	columnCursor int
 
+	// lastSearchNum is the last search number.
+	lastSearchNum int
+	// showGotoF displays the specified line if it is true.
+	showGotoF bool
+
 	// jumpTargetNum is the display position of search results.
 	jumpTargetNum int
 	// jumpTargetSection is the display position of search results.
@@ -130,8 +135,6 @@ type Document struct {
 	seekable bool
 	// Is it possible to reopen.
 	reopenable bool
-	// dupSectionHeader is true for lines that are duplicated in section header.
-	dupSectionHeader bool
 	// If nonMatch is true, non-matching lines are searched.
 	nonMatch bool
 }
@@ -194,12 +197,12 @@ func NewDocument() (*Document, error) {
 			TabWidth:        8,
 			MarkStyleWidth:  1,
 		},
-		ctlCh:            make(chan controlSpecifier),
-		memoryLimit:      100,
-		seekable:         true,
-		reopenable:       true,
-		store:            NewStore(),
-		dupSectionHeader: true,
+		ctlCh:         make(chan controlSpecifier),
+		memoryLimit:   100,
+		seekable:      true,
+		reopenable:    true,
+		store:         NewStore(),
+		lastSearchNum: -1,
 	}
 	if err := m.NewCache(); err != nil {
 		return nil, err

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -15,7 +15,6 @@ func (root *Root) moveTop(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	root.Doc.dupSectionHeader = true
 	root.Doc.moveTop()
 }
 

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -14,6 +14,7 @@ func (m *Document) moveLine(lN int) int {
 	if m.BufEndNum() == 0 {
 		return 0
 	}
+	m.showGotoF = true
 
 	if endLN := m.BufEndNum() - 1; lN > endLN {
 		lN = endLN
@@ -56,7 +57,6 @@ func (m *Document) moveLineNth(lN int, nTh int) (int, int) {
 
 	m.topLN = lN
 	m.topLX = listX[nTh]
-
 	return lN, nTh
 }
 
@@ -257,7 +257,7 @@ func (m *Document) moveNextSection(ctx context.Context) error {
 	if err != nil {
 		return ErrNoMoreSection
 	}
-	m.moveLine((lN - m.firstLine() + m.SectionHeaderNum) + m.SectionStartPosition)
+	m.moveLine((lN - m.firstLine()))
 	return nil
 }
 
@@ -279,13 +279,13 @@ func (m *Document) movePrevSectionLN(ctx context.Context, start int) error {
 		return ErrNoDelimiter
 	}
 
-	lN, err := m.prevSection(ctx, start+m.firstLine()-m.SectionHeaderNum)
+	lN, err := m.prevSection(ctx, start+m.firstLine())
 	if err != nil {
 		return ErrNoMoreSection
 	}
 	lN = (lN - m.firstLine()) + m.SectionStartPosition
 	lN = max(lN, m.BufStartNum())
-	m.moveLine(lN + m.SectionHeaderNum)
+	m.moveLine(lN)
 	return nil
 }
 

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -100,10 +100,10 @@ type SCR struct {
 	vHeight int
 	// startX is the start position of x.
 	startX int
-	// Process as a section header if the remaining value is 1 or more.
-	sectionHeaderLeft int
 	// sectionHeaderLN is the number of section headers.
 	sectionHeaderLN int
+	// sectionHeaderLeft is the number of remaining lines in sectionHeader.
+	sectionHeaderLeft int
 }
 
 // LineNumber is Number of logical lines and number of wrapping lines on the screen.
@@ -136,7 +136,7 @@ type general struct {
 
 	// TabWidth is tab stop num.
 	TabWidth int
-	// HeaderLen is number of header rows to be fixed.
+	// Header is number of header lines to be fixed.
 	Header int
 	// SkipLines is the rows to skip.
 	SkipLines int
@@ -148,6 +148,8 @@ type general struct {
 	SectionStartPosition int
 	// SectionHeaderNum is the number of lines in the section header.
 	SectionHeaderNum int
+	// sectionHeaderLen is the number of section headers.
+	sectionHeaderLen int
 	// HScrollWidth is the horizontal scroll width.
 	HScrollWidth string
 	// HScrollWidthNum is the horizontal scroll width.
@@ -928,11 +930,14 @@ func (root *Root) prepareView() {
 		root.scr.numbers = make([]LineNumber, root.scr.vHeight+1)
 	}
 
+	if root.scr.contents == nil {
+		root.scr.contents = make(map[int]LineC)
+	}
+	root.scr.sectionHeaderLN = -1
+
 	if root.Doc.ColumnWidth && len(root.Doc.columnWidths) == 0 {
 		root.Doc.setColumnWidths()
 	}
-
-	root.scr.contents = make(map[int]LineC)
 }
 
 // docSmall returns with bool whether the file to display fits on the screen.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -587,11 +587,15 @@ func (root *Root) returnStartPosition() int {
 
 // startSearchLN returns the start position of the search.
 func (root *Root) startSearchLN() int {
-	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.jumpTargetNum)
-	if l.number-root.Doc.topLN > root.Doc.topLN {
+	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.sectionHeaderLen + root.Doc.jumpTargetNum)
+	lN := l.number
+	if lN-root.Doc.topLN > root.Doc.topLN {
 		return 0
 	}
-	return l.number
+	if root.Doc.lastSearchNum >= 0 && lN >= root.Doc.lastSearchNum && root.Doc.lastSearchNum-lN <= root.Doc.SectionHeaderNum {
+		lN = root.Doc.lastSearchNum
+	}
+	return lN
 }
 
 // firstSearch performs the first search immediately after the input.
@@ -611,14 +615,19 @@ func (root *Root) firstSearch(ctx context.Context, t searchType) {
 // firstForwardSearch performs the first forward search immediately after the input.
 func (root *Root) firstForwardSearch(ctx context.Context) {
 	searcher := root.setSearcher(root.input.value, root.Config.CaseSensitive)
-	root.searchMove(ctx, true, root.startSearchLN(), searcher)
+	lN := root.startSearchLN()
+	root.searchMove(ctx, true, lN, searcher)
 }
 
 // nextSearch performs the next search.
 func (root *Root) nextSearch(ctx context.Context, str string) {
 	searcher := root.setSearcher(str, root.Config.CaseSensitive)
-	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.jumpTargetNum)
-	root.searchMove(ctx, true, l.number+1, searcher)
+	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.sectionHeaderLen + root.Doc.jumpTargetNum)
+	lN := l.number
+	if root.Doc.lastSearchNum >= 0 && lN >= root.Doc.lastSearchNum && root.Doc.lastSearchNum-lN <= root.Doc.SectionHeaderNum {
+		lN = root.Doc.lastSearchNum
+	}
+	root.searchMove(ctx, true, lN+1, searcher)
 }
 
 // firstBackSearch performs the first back search immediately after the input.
@@ -631,8 +640,12 @@ func (root *Root) firstBackSearch(ctx context.Context) {
 // nextBackSearch performs the next back search.
 func (root *Root) nextBackSearch(ctx context.Context, str string) {
 	searcher := root.setSearcher(str, root.Config.CaseSensitive)
-	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.jumpTargetNum)
-	root.searchMove(ctx, false, l.number-1, searcher)
+	l := root.scr.lineNumber(root.Doc.headerLen + root.Doc.sectionHeaderLen + root.Doc.jumpTargetNum)
+	lN := l.number
+	if root.Doc.lastSearchNum >= 0 && lN-root.Doc.lastSearchNum <= root.Doc.SectionHeaderNum {
+		lN = root.Doc.lastSearchNum
+	}
+	root.searchMove(ctx, false, lN-1, searcher)
 }
 
 // eventNextSearch represents search event.

--- a/oviewer/search_move.go
+++ b/oviewer/search_move.go
@@ -1,13 +1,16 @@
 package oviewer
 
-import "context"
+import (
+	"context"
+)
 
 // searchGoTo moves to the specified line and position after searching.
 // Go to the specified line +root.Doc.JumpTarget Go to.
 // If the search term is off screen, move until the search term is visible.
 func (m *Document) searchGoTo(lN int, x int) {
 	m.searchGoX(x)
-
+	m.showGotoF = true
+	m.lastSearchNum = lN
 	m.topLN = lN - m.firstLine()
 	m.moveYUp(m.jumpTargetNum)
 }


### PR DESCRIPTION
The displayed lines have been changed so that they are not affected by section headers.
However, if there are lines that should be displayed, they will be displayed by avoiding the section headers.
Also, if necessary, the search will start from the previous search line. Changed to display the mark style higher than the section-Header style.