### PR TITLE
Ignore "config not found" errors if not specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -530,8 +530,8 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		var configNotFoundError *viper.ConfigFileNotFoundError
-		if !errors.As(err, &configNotFoundError) {
+		var configNotFoundError viper.ConfigFileNotFoundError
+		if !errors.As(err, &configNotFoundError) || viper.GetBool("debug") {
 			fmt.Fprintln(os.Stderr, "failed to read config file:", err)
 			// If the config file is not found, it is not an error and will continue.
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -11,27 +11,40 @@ func Test_initConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
+		xdg     string
 		cfgFile string
 		wantErr bool
 	}{
 		{
 			name:    "test-ov.yaml",
+			xdg:     "",
 			cfgFile: "ov.yaml",
 			wantErr: false,
 		},
 		{
 			name:    "test-ov-less.yaml",
+			xdg:     "",
 			cfgFile: "ov-less.yaml",
 			wantErr: false,
 		},
 		{
 			name:    "no-file.yaml",
+			xdg:     "",
 			cfgFile: "no-file.yaml",
 			wantErr: true,
+		},
+		{
+			name:    "not found",
+			xdg:     "dummy",
+			cfgFile: "",
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.xdg != "" {
+				os.Setenv("XDG_CONFIG_HOME", tt.xdg)
+			}
 			cfgFile = tt.cfgFile
 			// Backup original stderr
 			origStderr := os.Stderr


### PR DESCRIPTION
Fixed a misunderstanding about how viper detects errors. 
Related: https://github.com/spf13/viper/issues/1139
This is a re-fix of #488.