### PR TITLE
docs: 📝 update instructions for source installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ov is a terminal pager.
   * 2.8. [nix (nixOS, Linux, or macOS)](#nix-(nixos,-linux,-or-macos))
   * 2.9. [Binary](#binary)
   * 2.10. [go install](#go-install)
-  * 2.11. [go get(details or developer version)](#go-get(details-or-developer-version))
+  * 2.11. [Build from source](#build-from-source)
   * 2.12. [Completion](#completion)
     * 2.12.1. [bash](#bash)
     * 2.12.2. [zsh](#zsh)
@@ -199,13 +199,13 @@ It will be installed in $GOPATH/bin by the following command.
 go install github.com/noborus/ov@latest
 ```
 
-###  2.11. <a name='go-get(details-or-developer-version)'></a>go get(details or developer version)
+###  2.11. <a name='build-from-source'></a>Build from source
 
-First of all, download only with the following command without installing it.
+First of all, clone this repo with either `git clone` or `gh repo clone`, then `cd` to the directory, for example:
 
 ```console
-go get -d github.com/noborus/ov
-cd $GOPATH/src/github.com/noborus/ov
+git clone https://github.com/noborus/ov.git
+cd ov
 ```
 
 Next, to install to $GOPATH/bin, run the make install command.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ First of all, clone this repo with either `git clone` or `gh repo clone`, then `
 
 ```console
 git clone https://github.com/noborus/ov.git
-cd ov
+cd ./ov/
 ```
 
 Next, to install to $GOPATH/bin, run the make install command.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ It will be installed in $GOPATH/bin by the following command.
 go install github.com/noborus/ov@latest
 ```
 
+Or to install the latest commit from master:
+
+```console
+go install github.com/noborus/ov@master
+```
+
 ###  2.11. <a name='build-from-source'></a>Build from source
 
 First of all, clone this repo with either `git clone` or `gh repo clone`, then `cd` to the directory, for example:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ First of all, clone this repo with either `git clone` or `gh repo clone`, then `
 
 ```console
 git clone https://github.com/noborus/ov.git
-cd ./ov/
+cd ov
 ```
 
 Next, to install to $GOPATH/bin, run the make install command.


### PR DESCRIPTION
as i tried to check for the fix to the erroneous `failed to read config file` message (as shown in #488), i first executed `go install github.com/noborus/ov@latest`, which just fetched the latest release build and did not included the fix (i wasn't aware of how to install from the `master` branch at the time). when i followed the option of `go get -d github.com/noborus/ov`, i got an error from `go` itself, saying:
```console
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
i assume that those without much knowledge of go like myself but want to have a local clone of the repo would be confused by this error message, which can be easily resolved by cloning the repo directly with `git clone` or `gh repo clone` instead, hence the reason why this commit was made.