### PR TITLE
Call preparaDraw in writeOriginal

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -964,6 +964,9 @@ func (root *Root) writeOriginal(output io.Writer) {
 		m.bottomLN = m.BufEndNum()
 	}
 
+	ctx := context.Background()
+	root.prepareDraw(ctx)
+
 	// header
 	header := max(0, root.scr.headerLN)
 	headerEnd := max(0, root.scr.headerEnd)

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -412,8 +412,6 @@ func TestRoot_writeOriginal(t *testing.T) {
 				root.Doc.SectionHeader = true
 			}
 			root.prepareScreen()
-			ctx := context.Background()
-			root.prepareDraw(ctx)
 			root.AfterWriteOriginal = tt.fields.AfterWriteOriginal
 			output := &bytes.Buffer{}
 			root.writeOriginal(output)


### PR DESCRIPTION
So that you don't have to call preparaDraw
before calling writeOriginal.

This is because docSmall is called before preparaDraw.