### PR TITLE
Fixed filter when skip-lines is specified

### DIFF
--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -61,15 +61,14 @@ func (root *Root) filterDocument(ctx context.Context, searcher Searcher) {
 	}
 
 	// Copy the header
-	if render.Header > 0 {
-		for ln := render.SkipLines; ln < render.Header; ln++ {
-			line, err := m.Line(ln)
-			if err != nil {
-				break
-			}
-			render.lineNumMap.Store(ln, ln)
-			writeLine(w, line)
+	for ln := 0; ln < render.firstLine(); ln++ {
+		line, err := m.Line(ln)
+		if err != nil {
+			log.Println(err)
+			break
 		}
+		render.lineNumMap.Store(ln, ln)
+		writeLine(w, line)
 	}
 	go m.filterWriter(ctx, searcher, m.firstLine(), filterDoc)
 	root.setMessagef(msg)
@@ -93,6 +92,7 @@ func (m *Document) filterWriter(ctx context.Context, searcher Searcher, startLN 
 		line, err := m.Line(lineNum)
 		if err != nil {
 			// deleted?
+			log.Println(err)
 			break
 		}
 		filterDoc.lineNumMap.Store(renderLN, lineNum)

--- a/oviewer/filter_test.go
+++ b/oviewer/filter_test.go
@@ -46,7 +46,7 @@ func TestRoot_Filter(t *testing.T) {
 	}
 }
 
-func TestRoot_filter(t *testing.T) {
+func TestRoot_filter2(t *testing.T) {
 	tcellNewScreen = fakeScreen
 	defer func() {
 		tcellNewScreen = tcell.NewScreen
@@ -118,6 +118,7 @@ func TestRoot_filterDocument(t *testing.T) {
 	}()
 	type fields struct {
 		fileNames []string
+		skipLines int
 		header    int
 	}
 	type args struct {
@@ -130,20 +131,22 @@ func TestRoot_filterDocument(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "test.txt",
+			name: "test3.txtMatch",
 			fields: fields{
-				fileNames: []string{filepath.Join(testdata, "test.txt")},
+				fileNames: []string{filepath.Join(testdata, "test3.txt")},
+				skipLines: 0,
 				header:    0,
 			},
 			args: args{
-				searcher: NewSearcher("test", nil, false, false),
+				searcher: NewSearcher("3", nil, false, false),
 			},
-			want: "test",
+			want: "3",
 		},
 		{
-			name: "test3.txt",
+			name: "test3.txtHeader",
 			fields: fields{
 				fileNames: []string{filepath.Join(testdata, "test3.txt")},
+				skipLines: 0,
 				header:    1,
 			},
 			args: args{
@@ -151,10 +154,23 @@ func TestRoot_filterDocument(t *testing.T) {
 			},
 			want: "1",
 		},
+		{
+			name: "test3.txtSkipLines",
+			fields: fields{
+				fileNames: []string{filepath.Join(testdata, "test3.txt")},
+				skipLines: 1,
+				header:    1,
+			},
+			args: args{
+				searcher: NewSearcher("4", nil, false, false),
+			},
+			want: "1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootFileReadHelper(t, tt.fields.fileNames...)
+			root.Doc.SkipLines = tt.fields.skipLines
 			root.Doc.Header = tt.fields.header
 			root.filterDocument(context.Background(), tt.args.searcher)
 			filterDoc := root.DocList[len(root.DocList)-1]


### PR DESCRIPTION
filter was not copying headers correctly when skip-lines was specified. It copies both skip-lines and headers.