### PR TITLE
Quit when the filter result fits within the screen

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,13 @@ func RunOviewer(args []string) error {
 		ov.Filter(nonMatchFilter, true)
 	}
 
+	if ov.QuitSmall && (filter != "" || nonMatchFilter != "") {
+		// UpdateInterval(50 * time.Millisecond) * 10 = 500ms.
+		// Quit if it fits on the screen within 500ms.
+		ov.QuitSmallCount = 10
+		ov.QuitSmall = false
+	}
+
 	if err := ov.Run(); err != nil {
 		return err
 	}

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -157,6 +157,13 @@ func (root *Root) everyUpdate(ctx context.Context) {
 	if atomic.SwapInt32(&root.Doc.watchRestart, 0) == 1 {
 		root.watchControl()
 	}
+
+	if root.QuitSmallCount > 0 {
+		root.QuitSmallCount--
+		if root.Doc.documentType == DocFilter && root.docSmall() {
+			root.WriteQuit(ctx)
+		}
+	}
 }
 
 // keyEvent processes key events.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -261,6 +261,8 @@ type Config struct {
 	IsWriteOriginal bool
 	// QuitSmall Quit if the output fits on one screen.
 	QuitSmall bool
+	// QuitSmallCount is the number of times to check if the output fits on one screen.
+	QuitSmallCount int
 	// CaseSensitive is case-sensitive if true.
 	CaseSensitive bool
 	// SmartCaseSensitive is lowercase search ignores case, if true.
@@ -665,7 +667,7 @@ func (root *Root) Run() error {
 
 	root.ViewSync(ctx)
 	// Exit if fits on screen
-	if root.QuitSmall && root.docSmall() {
+	if root.QuitSmall && root.DocumentLen() == 1 && root.docSmall() {
 		root.IsWriteOriginal = true
 		return nil
 	}
@@ -929,9 +931,6 @@ func mergeGeneral(src general, dst general) general {
 
 // docSmall returns with bool whether the file to display fits on the screen.
 func (root *Root) docSmall() bool {
-	if len(root.DocList) > 1 {
-		return false
-	}
 	root.prepareScreen()
 	m := root.Doc
 	if !m.BufEOF() {

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -451,16 +451,6 @@ func TestRoot_docSmall(t *testing.T) {
 			},
 			want: false,
 		},
-		{
-			name: "test multiple",
-			args: args{
-				fileNames: []string{
-					filepath.Join(testdata, "test.txt"),
-					filepath.Join(testdata, "test2.txt"),
-				},
-			},
-			want: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Changed when using --quit-if-one-screen and --filter together. 
Quit when the filter result fits within the screen.
Delay the determination that it fits within the screen.