### PR TITLE
Revert 6f70679

### DIFF
--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1042,7 +1042,7 @@ func TestRoot_ColumnWidthWrapMode(t *testing.T) {
 			root.Doc.WrapMode = tt.fields.wrapMode
 			root.Doc.x = tt.fields.x
 			root.Doc.columnCursor = tt.fields.columnCursor
-			root.Doc.setColumnWidths(root.scr)
+			root.Doc.setColumnWidths()
 			root.prepareDraw(ctx)
 			root.toggleWrapMode(ctx)
 			if root.Doc.WrapMode != tt.want.wrapMode {

--- a/oviewer/move_lateral_test.go
+++ b/oviewer/move_lateral_test.go
@@ -575,7 +575,7 @@ func TestDocument_moveColumnWidthRight(t *testing.T) {
 			scr := SCR{
 				numbers: numbers,
 			}
-			m.setColumnWidths(scr)
+			m.setColumnWidths()
 			m.x = tt.fields.x
 			if err := m.moveColumnRight(tt.args.n, scr, tt.args.cycle); (err != nil) != tt.wantErr {
 				t.Errorf("Document.moveColumnWidthRight() error = %v, wantErr %v", err, tt.wantErr)

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -82,7 +82,7 @@ func (root *Root) prepareDraw(ctx context.Context) {
 		root.Doc.showGotoF = false
 	}
 	if root.Doc.ColumnWidth && len(root.Doc.columnWidths) == 0 {
-		root.Doc.setColumnWidths(root.scr)
+		root.Doc.setColumnWidths()
 	}
 
 	// Prepare the lines.

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -587,7 +587,7 @@ func TestRoot_styleContent(t *testing.T) {
 			m.ColumnWidth = tt.fields.ColumnWidth
 			m.setMultiColorWords(tt.fields.multiColorWords)
 			m.setDelimiter(tt.fields.ColumnDelimiter)
-			m.setColumnWidths(root.scr)
+			m.setColumnWidths()
 			root.scr.lines = make(map[int]LineC)
 			root.prepareDraw(context.Background())
 			line := m.getLineC(tt.args.lineNum, m.TabWidth)
@@ -810,7 +810,7 @@ func TestRoot_columnWidthHighlight(t *testing.T) {
 			m.ColumnMode = true
 			root.prepareScreen()
 			root.prepareDraw(context.Background())
-			m.setColumnWidths(root.scr)
+			m.setColumnWidths()
 			t.Log(m.columnWidths)
 			m.columnCursor = tt.fields.columnCursor
 			line := root.Doc.getLineC(tt.args.lineNum, root.Doc.TabWidth)


### PR DESCRIPTION
This reverts commit  6f70679ed95b2edc06e0385ec5af6c48873bccd0. The scr was insufficient to determine the width.
Also, if the file is not fully loaded, it will not be determined.