### PR TITLE
Fixed exclamation mark input

### DIFF
--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -83,7 +83,7 @@ func NewInput() *Input {
 func (root *Root) inputEvent(ctx context.Context, ev *tcell.EventKey) {
 	// inputEvent returns input confirmed or not confirmed.
 	// Not confirmed or canceled.
-	evKey := root.inputKeyConfig.Capture(ev)
+	evKey := root.inputCapture(ev)
 	if ok := root.input.keyEvent(evKey); !ok {
 		root.incrementalSearch(ctx)
 		return
@@ -99,6 +99,19 @@ func (root *Root) inputEvent(ctx context.Context, ev *tcell.EventKey) {
 	nev := input.Event.Confirm(input.value)
 	root.postEvent(nev)
 	input.Event = normal()
+}
+
+func (root *Root) inputCapture(ev *tcell.EventKey) *tcell.EventKey {
+	if ev.Rune() == '!' {
+		if root.input.Event.Mode() != Filter {
+			return ev
+		}
+		if len(root.input.value) > 0 && root.input.value[len(root.input.value)-1] == '\\' {
+			return ev
+		}
+	}
+
+	return root.inputKeyConfig.Capture(ev)
 }
 
 // keyEvent handles the keystrokes of the input.

--- a/oviewer/input_search.go
+++ b/oviewer/input_search.go
@@ -120,7 +120,7 @@ func (e *eventInputSearch) Prompt() string {
 
 // Confirm returns the event when the input is confirmed.
 func (e *eventInputSearch) Confirm(str string) tcell.Event {
-	e.value = str
+	e.value = stripBackSlash(str)
 	e.clist.toLast(str)
 	e.SetEventNow()
 	return e
@@ -146,4 +146,18 @@ func (input *Input) searchCandidates(n int) []string {
 	listLen := len(input.SearchCandidate.list)
 	start := max(0, listLen-n)
 	return input.SearchCandidate.list[start:listLen]
+}
+
+// stripBackSlash removes the backslash from the string
+// when the backslash is followed by an exclamation mark.
+func stripBackSlash(str string) string {
+	if len(str) < 2 {
+		return str
+	}
+	idx := strings.Index(str, "\\!")
+	if idx < 0 {
+		return str
+	}
+	str = str[:idx] + str[idx+1:]
+	return str
 }

--- a/oviewer/input_search_test.go
+++ b/oviewer/input_search_test.go
@@ -267,3 +267,50 @@ func TestRoot_setSearchMode(t *testing.T) {
 		})
 	}
 }
+
+func Test_stripBackSlash(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "nonEsacpe",
+			args: args{
+				str: "\test",
+			},
+			want: "\test",
+		},
+		{
+			name: "nonEsacpe2",
+			args: args{
+				str: "!test",
+			},
+			want: "!test",
+		},
+		{
+			name: "backSlash1",
+			args: args{
+				str: `\!test`,
+			},
+			want: "!test",
+		},
+		{
+			name: "backSlash2",
+			args: args{
+				str: `te\!st`,
+			},
+			want: "te!st",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripBackSlash(tt.args.str); got != tt.want {
+				t.Errorf("stripSlash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixed a bug where exclamation marks could not be entered (with the default key bindings).
Normal input is now possible outside of filter.
In filter, they can be entered by placing a backslash in front of them.