### PR TITLE
Add align converter 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	code.rocketnine.space/tslocum/cbind v0.1.5
 	github.com/atotto/clipboard v0.1.4
-	github.com/creack/pty v1.1.21
+	github.com/creack/pty v1.1.23
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ code.rocketnine.space/tslocum/cbind v0.1.5/go.mod h1:LtfqJTzM7qhg88nAvNhx+VnTjZ0
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
-github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=
+github.com/creack/pty v1.1.23/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -28,6 +28,14 @@ var DefaultContent = content{
 	style: tcell.StyleDefault,
 }
 
+// SpaceContent is a space character.
+var SpaceContent = content{
+	mainc: ' ',
+	combc: nil,
+	width: 1,
+	style: tcell.StyleDefault,
+}
+
 // EOFC is the EOF character.
 const EOFC rune = '~'
 

--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -96,6 +96,9 @@ func parseString(conv Converter, str string, tabWidth int) contents {
 		}
 		st.parseChar(st.mainc, st.combc)
 	}
+	st.mainc = '\n'
+	st.combc = nil
+	conv.convert(st)
 	return st.lc
 }
 

--- a/oviewer/convert_align.go
+++ b/oviewer/convert_align.go
@@ -1,26 +1,28 @@
 package oviewer
 
 import (
+	"regexp"
+
 	"github.com/mattn/go-runewidth"
 )
 
+// align is a converter that aligns columns.
+// It is used to align columns when the delimiter is reached or to align columns by adding spaces to the end of the line.
 type align struct {
-	es        *escapeSequence
-	maxWidths []int // column max width
-	orgWidths []int
-	WidthF    bool
-	delimiter []rune
-	delmCount int
-	count     int
-	columnNum int
+	es           *escapeSequence
+	maxWidths    []int // column max width
+	orgWidths    []int
+	WidthF       bool
+	delimiter    string
+	delimiterReg *regexp.Regexp
+	count        int
 }
 
 func newAlignConverter(widthF bool) *align {
 	return &align{
-		es:        newESConverter(),
-		count:     0,
-		columnNum: 0,
-		WidthF:    widthF,
+		es:     newESConverter(),
+		count:  0,
+		WidthF: widthF,
 	}
 }
 
@@ -34,12 +36,16 @@ func (a *align) convert(st *parseState) bool {
 		return true
 	}
 
-	if a.columnNum >= len(a.maxWidths) {
+	if len(a.maxWidths) == 0 {
 		return false
 	}
 	a.count += 1
 	if runewidth.RuneWidth(st.mainc) > 1 {
 		a.count += 1
+	}
+
+	if st.mainc != '\n' {
+		return false
 	}
 
 	if a.WidthF {
@@ -50,37 +56,36 @@ func (a *align) convert(st *parseState) bool {
 
 func (a *align) reset() {
 	a.count = 0
-	a.columnNum = 0
-	a.delmCount = 0
-}
-
-// convertWidth accumulates one line and then adds spaces to align the column widths.
-func (a *align) convertDelm(st *parseState) bool {
-	if a.delmCount < len(a.delimiter) && st.mainc == a.delimiter[a.delmCount] {
-		a.delmCount += 1
-	} else {
-		a.delmCount = 0
-		return false
-	}
-	if a.delmCount > len(a.delimiter) {
-		return false
-	}
-	// Add space to align columns.
-	for ; a.count < a.maxWidths[a.columnNum]; a.count++ {
-		st.lc = append(st.lc, SpaceContent)
-	}
-	a.columnNum++
-	a.count = 0
-	a.delmCount = 0
-
-	return false
 }
 
 // convertDelm aligns the column widths by adding spaces when it reaches a delimiter.
-func (a *align) convertWidth(st *parseState) bool {
-	if st.mainc != '\n' {
+// convertDelm works line by line.
+func (a *align) convertDelm(st *parseState) bool {
+	str, pos := ContentsToStr(st.lc)
+	indexes := allIndex(str, a.delimiter, a.delimiterReg)
+	if len(indexes) == 0 {
 		return false
 	}
+	s := 0
+	lc := make(contents, 0, len(st.lc))
+	for c := 0; c < len(indexes); c++ {
+		e := pos.x(indexes[c][0])
+		lc = append(lc, st.lc[s:e]...)
+		width := e - s
+		// Add space to align columns.
+		for ; width < a.maxWidths[c]; width++ {
+			lc = append(lc, SpaceContent)
+		}
+		s = e
+	}
+	lc = append(lc, st.lc[s:]...)
+	st.lc = lc
+	return false
+}
+
+// convertWidth accumulates one line and then adds spaces to align the column widths.
+// convertWidth works line by line.
+func (a *align) convertWidth(st *parseState) bool {
 	s := 0
 	lc := make(contents, 0, len(st.lc))
 	for i := 0; i < len(a.orgWidths); i++ {

--- a/oviewer/convert_align.go
+++ b/oviewer/convert_align.go
@@ -1,0 +1,56 @@
+package oviewer
+
+import "github.com/mattn/go-runewidth"
+
+type align struct {
+	Columns   []int // column width
+	delimiter []rune
+	delmCount int
+	count     int
+	columnNum int
+}
+
+func newAlignConverter() *align {
+	return &align{
+		count:     0,
+		columnNum: 0,
+	}
+}
+
+// convert converts only escape sequence codes to display characters and returns them as is.
+// Returns true if it is an escape sequence and a non-printing character.
+func (a *align) convert(st *parseState) bool {
+	if len(st.lc) == 0 {
+		a.count = 0
+		a.columnNum = 0
+		a.delmCount = 0
+	}
+
+	a.count += 1
+	if runewidth.RuneWidth(st.mainc) > 1 {
+		a.count += 1
+	}
+
+	if len(a.Columns) <= a.columnNum {
+		return false
+	}
+	if len(a.delimiter) > a.delmCount && st.mainc == a.delimiter[a.delmCount] {
+		a.delmCount += 1
+	} else {
+		a.delmCount = 0
+		return false
+	}
+	if len(a.delimiter) < a.delmCount {
+		return false
+	}
+	// Add space to align columns.
+	for ; a.count < a.Columns[a.columnNum]; a.count++ {
+		c := DefaultContent
+		st.lc = append(st.lc, c)
+	}
+	a.count = 0
+	a.columnNum++
+	a.delmCount = 0
+
+	return false
+}

--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -149,7 +149,7 @@ func (es *escapeSequence) convert(st *parseState) bool {
 		es.state = ansiEscape
 		return true
 	case '\n':
-		return true
+		return false
 	}
 	return false
 }

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -55,6 +55,8 @@ type Document struct {
 
 	// conv is an interface that converts escape sequences, etc.
 	conv Converter
+	// alignConv is an interface that converts alignment.
+	alignConv *align
 
 	// fileName is the file name to display.
 	FileName string
@@ -222,6 +224,7 @@ func NewDocument() (*Document, error) {
 	if err := m.NewCache(); err != nil {
 		return nil, err
 	}
+	m.alignConv = newAlignConverter()
 	m.conv = m.converterType(m.general.Converter)
 	return m, nil
 }
@@ -244,6 +247,8 @@ func (m *Document) converterType(name string) Converter {
 		return newRawConverter()
 	case "es":
 		return newESConverter()
+	case "align":
+		return m.alignConv
 	}
 	return defaultConverter
 }

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -224,7 +224,7 @@ func NewDocument() (*Document, error) {
 	if err := m.NewCache(); err != nil {
 		return nil, err
 	}
-	m.alignConv = newAlignConverter()
+	m.alignConv = newAlignConverter(m.ColumnWidth)
 	m.conv = m.converterType(m.general.Converter)
 	return m, nil
 }

--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -236,9 +236,16 @@ func leftX(width int, lc contents) []int {
 	if width <= 0 {
 		return []int{0}
 	}
-	listX := make([]int, 0, (len(lc)/width)+1)
+	if len(lc) == 0 {
+		return []int{0}
+	}
+	end := len(lc)
+	if lc[len(lc)-1].mainc == '\n' {
+		end--
+	}
+	listX := make([]int, 0, (end/width)+1)
 	listX = append(listX, 0)
-	for n := width; n < len(lc); n += width {
+	for n := width; n < end; n += width {
 		if lc[n-1].width == 2 {
 			n--
 		}

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -101,7 +101,8 @@ func (root *Root) setAlignColumnWidths() {
 	m := root.Doc
 	m.alignConv.WidthF = m.ColumnWidth
 	if !m.alignConv.WidthF {
-		root.Doc.alignConv.delimiter = []rune(root.Doc.ColumnDelimiter)
+		root.Doc.alignConv.delimiter = m.ColumnDelimiter
+		root.Doc.alignConv.delimiterReg = m.ColumnDelimiterReg
 	}
 
 	maxWidths := make([]int, 0, len(m.alignConv.maxWidths))

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -95,6 +95,13 @@ func allStringIndex(s string, substr string) [][]int {
 		s = s[pos+width:]
 		result = append(result, []int{pos + offSet, pos + offSet + width})
 		offSet += pos + width
+
+		if len(s) > 0 && s[0] == '"' {
+			qpos := strings.Index(s[1:], `"`)
+			s = s[qpos+2:]
+			offSet += qpos + 2
+		}
+
 		pos = strings.Index(s, substr)
 	}
 	return result

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -520,6 +520,28 @@ func Test_allStringIndex(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "testDoubleQuote",
+			args: args{
+				s:      `a,"b,c",d`,
+				substr: ",",
+			},
+			want: [][]int{
+				{1, 2},
+				{7, 8},
+			},
+		},
+		{
+			name: "testDoubleQuote2",
+			args: args{
+				s:      `a,"060  ",d`,
+				substr: ",",
+			},
+			want: [][]int{
+				{1, 2},
+				{9, 10},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Add converter align to align columns split by dlimiter and columns split by width.
Adds space to columns that are short of space to fit the maximum width of columns on the screen.
Add support for disabling delimiters in double quotes.