### PR TITLE
Fix paste mistakes

### DIFF
--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -535,6 +535,9 @@ func (root *Root) sendSearchMove(lineNum int) {
 
 // incrementalSearch performs incremental search by setting and input mode.
 func (root *Root) incrementalSearch(ctx context.Context) {
+	if root.Screen.HasPendingEvent() {
+		return
+	}
 	if !root.Config.Incsearch {
 		return
 	}


### PR DESCRIPTION
Fix the conditions of incremental search,
If the event is accumulated, do not execute.

The paste on the system side (not a `tcell` event) is to miss the event because a key event occurs for each character.

This fixes #613.