### PR TITLE
Avoid sector header when marking

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -274,15 +274,16 @@ func (root *Root) markPrev(context.Context) {
 
 // addMark marks the current line number.
 func (root *Root) addMark(context.Context) {
-	lN := min(root.Doc.topLN+root.Doc.firstLine(), root.Doc.BufEndNum())
+	lN := root.firstBodyLine()
 	root.Doc.marked = remove(root.Doc.marked, lN)
 	root.Doc.marked = append(root.Doc.marked, lN)
+	root.Doc.markedPoint++
 	root.setMessagef("Marked to line %d", lN-root.Doc.firstLine()+1)
 }
 
 // removeMark removes the current line number from the mark.
 func (root *Root) removeMark(context.Context) {
-	lN := root.Doc.topLN + root.Doc.firstLine()
+	lN := root.firstBodyLine()
 	marked := remove(root.Doc.marked, lN)
 	if len(root.Doc.marked) == len(marked) {
 		root.setMessagef("Not marked line %d", lN-root.Doc.firstLine()+1)
@@ -290,6 +291,12 @@ func (root *Root) removeMark(context.Context) {
 	}
 	root.Doc.marked = marked
 	root.setMessagef("Remove the mark at line %d", lN-root.Doc.firstLine()+1)
+}
+
+// firstBodyLine returns the first line number of the body.
+func (root *Root) firstBodyLine() int {
+	ln := root.scr.lineNumber(root.Doc.headerHeight + root.Doc.sectionHeaderHeight)
+	return ln.number
 }
 
 // removeAllMark removes all marks.

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1061,24 +1061,29 @@ func TestRoot_Mark(t *testing.T) {
 	}()
 	root := rootFileReadHelper(t, filepath.Join(testdata, "test3.txt"))
 	t.Run("TestMark", func(t *testing.T) {
+		root.prepareScreen()
 		ctx := context.Background()
 		root.Doc.topLN = 1
+		root.draw(ctx)
 		root.addMark(ctx)
 		if !reflect.DeepEqual(root.Doc.marked, []int{1}) {
 			t.Errorf("addMark() = %#v, want %#v", root.Doc.marked, []int{1})
 		}
 		root.Doc.topLN = 10
+		root.draw(ctx)
 		root.addMark(ctx)
 		if !reflect.DeepEqual(root.Doc.marked, []int{1, 10}) {
 			t.Errorf("addMark() = %#v, want %#v", root.Doc.marked, []int{1, 10})
 		}
 		root.Doc.topLN = 1
+		root.draw(ctx)
 		root.removeMark(ctx)
 		if !reflect.DeepEqual(root.Doc.marked, []int{10}) {
 			t.Errorf("removeAllMark() = %#v, want %#v", root.Doc.marked, []int{10})
 		}
 		root.removeMark(ctx)
 		root.Doc.topLN = 2
+		root.draw(ctx)
 		root.addMark(ctx)
 		if !reflect.DeepEqual(root.Doc.marked, []int{10, 2}) {
 			t.Errorf("addMark() = %#v, want %#v", root.Doc.marked, []int{10, 2})

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -50,6 +50,8 @@ func (root *Root) draw(ctx context.Context) {
 func (root *Root) drawBody(lX int, lN int) (int, int) {
 	m := root.Doc
 
+	markStyleWidth := min(root.scr.vWidth, root.Doc.general.MarkStyleWidth)
+
 	wrapNum := m.numOfWrap(lX, lN)
 	for y := m.headerHeight; y < root.scr.vHeight-statusLine; y++ {
 		line, ok := root.scr.lines[lN]
@@ -69,6 +71,7 @@ func (root *Root) drawBody(lX int, lN int) (int, int) {
 				root.hideOtherSection(y, line)
 			}
 		}
+		root.markStyle(lN, y, markStyleWidth)
 
 		wrapNum++
 		if nextLX == 0 {
@@ -269,8 +272,6 @@ func (root *Root) clearY(y int) {
 // coordinatesStyle applies the style of the coordinates.
 func (root *Root) coordinatesStyle(lN int, y int) {
 	root.alternateRowsStyle(lN, y)
-	markStyleWidth := min(root.scr.vWidth, root.Doc.general.MarkStyleWidth)
-	root.markStyle(lN, y, markStyleWidth)
 	if root.Doc.jumpTargetHeight != 0 && root.Doc.headerHeight+root.Doc.jumpTargetHeight == y {
 		root.yStyle(y, root.StyleJumpTargetLine)
 	}


### PR DESCRIPTION
Avoid the section header and mark it, when marking.
This solves #620.