### PR TITLE
Change the specifications of column by delimiter

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -477,6 +477,8 @@ func (root *Root) esFormat(ctx context.Context) {
 // setDelimiter sets the delimiter string.
 func (root *Root) setDelimiter(input string) {
 	root.Doc.setDelimiter(input)
+	root.Doc.optimalCursor(root.scr, root.Doc.columnCursor)
+	root.Doc.columnCursor = max(root.Doc.columnStart, root.Doc.columnCursor)
 	root.setMessagef("Set delimiter %s", input)
 }
 
@@ -796,7 +798,7 @@ func (m *Document) isColumnShrink(cursor int) (bool, error) {
 	if m.Converter != convAlign {
 		return false, ErrNotAlignMode
 	}
-	if cursor >= len(m.alignConv.columnAttrs) {
+	if cursor < 0 || cursor >= len(m.alignConv.columnAttrs) {
 		return false, ErrNoColumnSelected
 	}
 	return m.alignConv.columnAttrs[cursor].shrink, nil

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -938,7 +938,7 @@ func TestRoot_ColumnDelimiterWrapMode(t *testing.T) {
 				wrapMode:     false,
 			},
 			want: want{
-				x:            2,
+				x:            10,
 				columnCursor: 1,
 				wrapMode:     true,
 			},

--- a/oviewer/convert_align.go
+++ b/oviewer/convert_align.go
@@ -35,7 +35,9 @@ func newAlignConverter(widthF bool) *align {
 	}
 }
 
-// convert converts only escape sequence codes to display characters and returns them as is.
+// convert aligns the columns.
+// convert also shrinks and right-aligns the columns.
+// (It only processes escape sequences until the end of the line is reached.)
 // Returns true if it is an escape sequence and a non-printing character.
 func (a *align) convert(st *parseState) bool {
 	if len(st.lc) == 0 {
@@ -80,47 +82,29 @@ func (a *align) convertDelm(src contents) contents {
 	if len(indexes) == 0 {
 		return src
 	}
-	delmWidth := runewidth.StringWidth(a.delimiter)
 	dst := make(contents, 0, len(src))
-
-	s := 0
-	for c := 0; c < len(indexes); c++ {
-		e := pos.x(indexes[c][0])
-		width := e - s
-		if width <= 0 {
-			break
-		}
-
-		// shrink column.
-		if a.isShrink(c) {
-			if s == 0 {
-				dst = appendShrink(dst, nil)
-			} else {
-				dst = appendShrink(dst, src[s:s+delmWidth])
-			}
-			s = e
-			continue
-		}
-
-		addSpace := 0
-		if c < len(a.maxWidths) {
-			addSpace = ((a.maxWidths[c] + 1) - width)
-		}
-
-		if a.isRightAlign(c) {
-			dst = appendSpaces(dst, addSpace)
-			dst = append(dst, src[s:e]...)
+	start := pos.x(0)
+	for columnNum := 0; columnNum < len(indexes); columnNum++ {
+		end := pos.x(indexes[columnNum][0]) // Start of the delimiter.
+		delmEnd := pos.x(indexes[columnNum][1])
+		if a.isShrink(columnNum) {
+			// shrink column.
+			dst = appendShrink(dst)
 		} else {
-			dst = append(dst, src[s:e]...)
-			dst = appendSpaces(dst, addSpace)
+			// content column.
+			dst = a.appendColumn(dst, columnNum, src[start:end])
 		}
-		s = e
+		// Add the delimiter.
+		dst = append(dst, src[end:delmEnd]...)
+		start = delmEnd
 	}
-	if !a.isShrink(len(indexes)) {
-		dst = append(dst, src[s:]...)
+
+	// Add the remaining content.
+	if a.isShrink(len(indexes)) {
+		dst = appendShrink(dst)
 		return dst
 	}
-	dst = appendShrink(dst, src[s:s+delmWidth])
+	dst = append(dst, src[start:]...)
 	return dst
 }
 
@@ -130,18 +114,20 @@ func (a *align) convertWidth(src contents) contents {
 	dst := make(contents, 0, len(src))
 
 	start := 0
-	for c := 0; c < len(a.orgWidths); c++ {
-		end := findColumnEnd(src, a.orgWidths, c, start) + 1
+	for columnNum := 0; columnNum < len(a.orgWidths); columnNum++ {
+		end := findColumnEnd(src, a.orgWidths, columnNum, start) + 1
 		end = min(end, len(src))
 
-		if a.isShrink(c) {
-			dst = appendShrink(dst, nil)
+		// shrink column.
+		if a.isShrink(columnNum) {
+			dst = appendShrink(dst)
 			dst = append(dst, SpaceContent)
-			a.maxWidths[c] = runewidth.RuneWidth(Shrink)
+			a.maxWidths[columnNum] = runewidth.RuneWidth(Shrink)
 			start = end
 			continue
 		}
 
+		// content column.
 		tStart := findStartWithTrim(src, start)
 		tEnd := findEndWidthTrim(src, end)
 		// If the column width is 0, skip.
@@ -149,46 +135,52 @@ func (a *align) convertWidth(src contents) contents {
 			start = end
 			continue
 		}
-
-		padding := 0
-		if c < len(a.maxWidths) {
-			padding = (a.maxWidths[c] - (tEnd - tStart))
-		}
-		start = end
-
-		if a.isRightAlign(c) {
-			// Add left space to align columns.
-			dst = appendSpaces(dst, padding)
-			// Add content.
-			dst = append(dst, src[tStart:tEnd]...)
-		} else {
-			// Add content.
-			dst = append(dst, src[tStart:tEnd]...)
-			// Add right space to align columns.
-			dst = appendSpaces(dst, padding)
-		}
+		dst = a.appendColumn(dst, columnNum, src[tStart:tEnd])
 		dst = append(dst, SpaceContent)
+		start = end
 	}
 
 	// Add the remaining content.
-	if !a.isShrink(len(a.orgWidths)) {
-		dst = append(dst, src[start:]...)
+	if a.isShrink(len(a.orgWidths)) {
+		dst = appendShrink(dst)
 		return dst
 	}
-	dst = appendShrink(dst, nil)
+	dst = append(dst, src[start:]...)
 	return dst
 }
 
-func appendShrink(lc contents, delm contents) contents {
-	lc = append(lc, delm...)
+// appendColumn adds column content to the lc.
+func (a *align) appendColumn(lc contents, columnNum int, column contents) contents {
+	padding := 0
+	if columnNum < len(a.maxWidths) {
+		padding = (a.maxWidths[columnNum] - len(column))
+	}
+
+	if a.isRightAlign(columnNum) {
+		// Add left space to align columns.
+		lc = appendPaddings(lc, padding)
+		// Add content.
+		lc = append(lc, column...)
+		return lc
+	}
+	// Add content.
+	lc = append(lc, column...)
+	// Add right space to align columns.
+	lc = appendPaddings(lc, padding)
+	return lc
+}
+
+// appendShrink adds a shrink column to the lc.
+func appendShrink(lc contents) contents {
 	lc = append(lc, ShrinkContent)
 	if ShrinkContent.width > 1 {
-		lc = append(lc, SpaceContent)
+		lc = append(lc, DefaultContent)
 	}
 	return lc
 }
 
-func appendSpaces(lc contents, num int) contents {
+// appendPaddings adds spaces to the lc.
+func appendPaddings(lc contents, num int) contents {
 	for i := 0; i < num; i++ {
 		lc = append(lc, SpaceContent)
 	}

--- a/oviewer/convert_align_test.go
+++ b/oviewer/convert_align_test.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 )
@@ -29,7 +30,7 @@ func Test_align_convert(t *testing.T) {
 			name: "convertAlignDelm",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2},
+				maxWidths: []int{2, 2},
 				WidthF:    false,
 				delimiter: ",",
 				count:     0,
@@ -180,7 +181,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelm1",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2},
+				maxWidths: []int{2, 2},
 				WidthF:    false,
 				delimiter: ",",
 				count:     0,
@@ -194,7 +195,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelm2",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2, 2, 2, 2, 2},
+				maxWidths: []int{2, 2, 2, 2, 2, 2},
 				WidthF:    false,
 				delimiter: ",",
 				count:     0,
@@ -208,7 +209,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelmShrink1",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2, 2, 2, 2, 2},
+				maxWidths: []int{2, 2, 2, 2, 2, 2},
 				columns: []columnAttribute{
 					{shrink: false, rightAlign: false},
 					{shrink: true, rightAlign: false},
@@ -229,7 +230,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelmShrink2",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2, 2, 2, 2, 2},
+				maxWidths: []int{2, 2, 2, 2, 2, 2},
 				columns: []columnAttribute{
 					{shrink: true, rightAlign: false},
 					{shrink: false, rightAlign: false},
@@ -250,7 +251,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelmShrink3",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2, 2, 2, 2, 2},
+				maxWidths: []int{2, 2, 2, 2, 2, 2},
 				columns: []columnAttribute{
 					{shrink: false, rightAlign: false},
 					{shrink: false, rightAlign: false},
@@ -272,7 +273,7 @@ func Test_align_convertDelm(t *testing.T) {
 			name: "convertAlignDelmRight",
 			fields: fields{
 				es:        newESConverter(),
-				maxWidths: []int{1, 2, 2, 2, 2, 2},
+				maxWidths: []int{2, 2, 2, 2, 2, 2},
 				columns: []columnAttribute{
 					{shrink: false, rightAlign: true},
 					{shrink: false, rightAlign: false},
@@ -529,6 +530,53 @@ func Test_align_isRightAlign(t *testing.T) {
 			}
 			if got := a.isRightAlign(tt.args.col); got != tt.want {
 				t.Errorf("align.isRightAlign() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_appendShrink(t *testing.T) {
+	type args struct {
+		lc contents
+	}
+	type fields struct {
+		shrink rune
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   contents
+	}{
+		{
+			name: "appendShrink1",
+			fields: fields{
+				shrink: '.',
+			},
+			args: args{
+				lc: StrToContents("abc", 8),
+			},
+			want: StrToContents("abc.", 8),
+		},
+		{
+			name: "appendShrink2",
+			fields: fields{
+				shrink: '略',
+			},
+			args: args{
+				lc: StrToContents("abc", 8),
+			},
+			want: StrToContents("abc略", 8),
+		},
+	}
+	for _, tt := range tests {
+		SetShrinkContent(tt.fields.shrink)
+		t.Cleanup(func() {
+			SetShrinkContent(Shrink)
+		})
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendShrink(tt.args.lc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appendShrink() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -112,6 +112,9 @@ type Document struct {
 	// columnCursor is the number of columns.
 	columnCursor int
 
+	// columnStart is the starting position of the column 0 or 1.
+	columnStart int
+
 	// lastSearchLN is the last search line number.
 	lastSearchLN int
 	// showGotoF displays the specified line if it is true.

--- a/oviewer/move_lateral_test.go
+++ b/oviewer/move_lateral_test.go
@@ -305,7 +305,7 @@ func Test_splitDelimiter(t *testing.T) {
 				delimiter:    ",",
 				delimiterReg: nil,
 			},
-			want: []int{0, 3, 5},
+			want: []int{1, 3, 5},
 		},
 		{
 			name: "abc2",
@@ -314,7 +314,7 @@ func Test_splitDelimiter(t *testing.T) {
 				delimiter:    "|",
 				delimiterReg: nil,
 			},
-			want: []int{2, 5, 8}, // 23 | 56 | 89
+			want: []int{0, 3, 6, 9},
 		},
 	}
 	for _, tt := range tests {
@@ -365,7 +365,7 @@ func TestDocument_optimalCursor(t *testing.T) {
 			args: args{
 				cursor: 4,
 			},
-			want: 2,
+			want: 1,
 		},
 		{
 			name: "CSVLeft",

--- a/oviewer/move_test.go
+++ b/oviewer/move_test.go
@@ -362,11 +362,11 @@ func TestRoot_moveColumn(t *testing.T) {
 			fields: fields{
 				fileName:     filepath.Join(testdata, "column.txt"),
 				delimiter:    "|",
-				columnCursor: 3,
+				columnCursor: 4,
 			},
 			want: want{
-				leftOne:  2,
-				rightOne: 0,
+				leftOne:  3,
+				rightOne: 1,
 			},
 		},
 	}

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -680,7 +680,7 @@ func TestRoot_columnDelimiterHighlight(t *testing.T) {
 			name: "Test columnDelimiterHighlight1",
 			fields: fields{
 				columnDelimiter: "|",
-				columnCursor:    0,
+				columnCursor:    1,
 			},
 			args: args{
 				lineNum: 2,
@@ -694,7 +694,7 @@ func TestRoot_columnDelimiterHighlight(t *testing.T) {
 			name: "Test columnDelimiterHighlight2",
 			fields: fields{
 				columnDelimiter: "|",
-				columnCursor:    1,
+				columnCursor:    2,
 			},
 			args: args{
 				lineNum: 2,
@@ -708,7 +708,7 @@ func TestRoot_columnDelimiterHighlight(t *testing.T) {
 			name: "Test columnDelimiterHighlight3",
 			fields: fields{
 				columnDelimiter: "|",
-				columnCursor:    2,
+				columnCursor:    3,
 			},
 			args: args{
 				lineNum: 2,
@@ -722,7 +722,7 @@ func TestRoot_columnDelimiterHighlight(t *testing.T) {
 			name: "Test columnDelimiterHighlight4",
 			fields: fields{
 				columnDelimiter: "|",
-				columnCursor:    3,
+				columnCursor:    4,
 			},
 			args: args{
 				lineNum: 0,
@@ -1116,7 +1116,7 @@ func TestRoot_setAlignConverter(t *testing.T) {
 				columnWidth:     false,
 				columnDelimiter: "|",
 			},
-			want: []int{-1, 7, 7, 7},
+			want: []int{0, 7, 7, 7},
 		},
 		{
 			name: "Test setAlignConverterDelimiter2",
@@ -1126,7 +1126,7 @@ func TestRoot_setAlignConverter(t *testing.T) {
 				columnWidth:     false,
 				columnDelimiter: ",",
 			},
-			want: []int{0, 5, 1},
+			want: []int{1, 5, 1},
 		},
 		{
 			name: "Test setAlignNoColumn",
@@ -1186,7 +1186,7 @@ func Test_maxWidthsDelm(t *testing.T) {
 				delimiter:    ",",
 				delimiterReg: regexpCompile(",", false),
 			},
-			want: []int{0, 2, 2, 2, 2, 2},
+			want: []int{1, 2, 2, 2, 2, 2},
 		},
 		{
 			name: "Test maxWidthsDelm2",


### PR DESCRIPTION
If it starts with the Delimiter character (enclosed by Delimiter), change the start of the line from 1 instead of 0.

Maxwidth is changed to the width excluding delimiter.

Add Column to add AppendColumn as a function.

Improve comments.