### PR TITLE
Change to suspend with SIGSTOP

### DIFF
--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -2,7 +2,6 @@ package oviewer
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -1283,17 +1282,6 @@ func TestRoot_modeConfig(t *testing.T) {
 				t.Errorf("Root.modeConfig() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestRoot_suspend(t *testing.T) {
-	root := rootHelper(t)
-	shell := os.Getenv("SHELL")
-	if got := root.shellSuspendResume(shell); got != nil {
-		t.Errorf("shellSuspendResume() = %v, want %v", got, nil)
-	}
-	if got := root.shellSuspendResume(""); got != nil {
-		t.Errorf("shellSuspendResume() = %v, want %v", got, nil)
 	}
 }
 

--- a/oviewer/suspend.go
+++ b/oviewer/suspend.go
@@ -15,3 +15,12 @@ func registerSIGTSTP() chan os.Signal {
 	signal.Notify(sigSuspend, syscall.SIGTSTP)
 	return sigSuspend
 }
+
+// suspendProcess sends SIGSTOP signal to itself.
+func suspendProcess() error {
+	pid := syscall.Getpid()
+	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil {
+		return err
+	}
+	return nil
+}

--- a/oviewer/suspend_windows.go
+++ b/oviewer/suspend_windows.go
@@ -12,3 +12,8 @@ func registerSIGTSTP() chan os.Signal {
 	sigSuspend := make(chan os.Signal, 1)
 	return sigSuspend
 }
+
+// suspendProcess is a dummy function.
+func suspendProcess() error {
+	return nil
+}


### PR DESCRIPTION
Change suspend from subshell to SIGSTOP suspend.
However, if Windows or OV_SUBSHELL is set, it will remain in subshell.

Solve #630.