### PR TITLE
Send SIGSTOP to the process group

### DIFF
--- a/oviewer/suspend.go
+++ b/oviewer/suspend.go
@@ -16,11 +16,8 @@ func registerSIGTSTP() chan os.Signal {
 	return sigSuspend
 }
 
-// suspendProcess sends SIGSTOP signal to itself.
+// suspendProcess sends SIGSTOP signal to the process group.
 func suspendProcess() error {
-	pid := syscall.Getpid()
-	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil {
-		return err
-	}
-	return nil
+	pid := syscall.Getpgrp()
+	return syscall.Kill(-pid, syscall.SIGSTOP)
 }


### PR DESCRIPTION
This change ensures that all processes in the group are suspended, not just the main process.
It was modified by the re-comment of #630.