### PR TITLE
Fixed root.searcher is race condition

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -184,10 +184,10 @@ func (root *Root) watchControl() {
 
 // searchGo will go to the line with the matching term after searching.
 // Jump by section if JumpTargetSection is true.
-func (root *Root) searchGo(ctx context.Context, lN int) {
+func (root *Root) searchGo(ctx context.Context, lN int, searcher Searcher) {
 	root.resetSelect()
 	root.Doc.lastSearchLN = lN
-	x := root.searchXPos(lN)
+	x := root.searchXPos(lN, searcher)
 	if root.Doc.jumpTargetSection {
 		root.Doc.searchGoSection(ctx, lN, x)
 		return

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -802,7 +802,7 @@ func TestRoot_searchGo(t *testing.T) {
 			root.Doc.jumpTargetSection = tt.fields.jumpTargetSection
 			root.setSectionDelimiter(tt.fields.sectionDelimiter)
 			root.Doc.SectionHeader = true
-			root.searchGo(ctx, tt.args.lN)
+			root.searchGo(ctx, tt.args.lN, root.searcher)
 			if root.Doc.topLN != tt.want {
 				t.Errorf("searchGo() = %v, want %v", root.Doc.topLN, tt.want)
 			}

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -71,7 +71,7 @@ func (root *Root) event(ctx context.Context, ev tcell.Event) bool {
 	case *eventNextBackSearch:
 		root.backSearch(ctx, ev.str, -1)
 	case *eventSearchMove:
-		root.searchGo(ctx, ev.value)
+		root.searchGo(ctx, ev.ln, ev.searcher)
 	case *eventGoto:
 		root.goLine(ev.value)
 	case *eventHeader:

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -216,9 +216,9 @@ func (root *Root) searchPosition(str string) [][]int {
 }
 
 // searchXPos returns the x position of the first match.
-func (root *Root) searchXPos(lineNum int) int {
+func (root *Root) searchXPos(lineNum int, searcher Searcher) int {
 	line := root.Doc.getLineC(lineNum)
-	indexes := root.searcher.FindAll(line.str)
+	indexes := searcher.FindAll(line.str)
 	if len(indexes) == 0 {
 		return 0
 	}
@@ -278,7 +278,7 @@ func (root *Root) searchMove(ctx context.Context, forward bool, lineNum int, sea
 		if err != nil {
 			return fmt.Errorf("search:%w:%v", err, word)
 		}
-		root.sendSearchMove(n)
+		root.sendSearchMove(n, searcher)
 		return nil
 	})
 
@@ -523,13 +523,15 @@ func (root *Root) sendSearchQuit() {
 // eventSearchMove represents the move input mode.
 type eventSearchMove struct {
 	tcell.EventTime
-	value int
+	ln       int
+	searcher Searcher
 }
 
-func (root *Root) sendSearchMove(lineNum int) {
+func (root *Root) sendSearchMove(lineNum int, searcher Searcher) {
 	ev := &eventSearchMove{}
 	ev.SetEventNow()
-	ev.value = lineNum
+	ev.ln = lineNum
+	ev.searcher = searcher
 	root.postEvent(ev)
 }
 
@@ -566,7 +568,7 @@ func (root *Root) incSearch(ctx context.Context, forward bool, lineNum int) {
 			root.debugMessage(fmt.Sprintf("incSearch: %s", err))
 			return
 		}
-		root.sendSearchMove(n)
+		root.sendSearchMove(n, searcher)
 	}()
 }
 


### PR DESCRIPTION
Change searcher to an argument,
because root.searcher will be in a race condition in another goroutine.

This is a fix to #641.