### PR TITLE
Add support of ANSI escape sequence for clear line

### DIFF
--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -71,6 +71,7 @@ type parseState struct {
 	mainc     rune
 	combc     []rune
 	style     tcell.Style
+	eolStyle  tcell.Style
 	bsContent content
 	tabWidth  int
 	tabx      int
@@ -98,13 +99,20 @@ func RawStrToContents(str string, tabWidth int) contents {
 	return parseString(newRawConverter(), str, tabWidth)
 }
 
-// parseString converts a string to lineContents.
-// parseString is converted character by character by Converter.
-// If tabwidth is set to -1, \t is displayed instead of functioning as a tab.
+// parseString converts a string to contents.
+// This function wraps parseLine and is used when line styles are not needed.
 func parseString(conv Converter, str string, tabWidth int) contents {
+	lc, _ := parseLine(conv, str, tabWidth)
+	return lc
+}
+
+// parseLine converts a string to lineContents and eolStyle, and returns them.
+// If tabWidth is set to -1, \t is displayed instead of functioning as a tab.
+func parseLine(conv Converter, str string, tabWidth int) (contents, tcell.Style) {
 	st := &parseState{
 		lc:        make(contents, 0, len(str)),
 		style:     tcell.StyleDefault,
+		eolStyle:  tcell.StyleDefault,
 		tabWidth:  tabWidth,
 		tabx:      0,
 		bsFlag:    false,
@@ -125,7 +133,7 @@ func parseString(conv Converter, str string, tabWidth int) contents {
 	st.mainc = '\n'
 	st.combc = nil
 	conv.convert(st)
-	return st.lc
+	return st.lc, st.eolStyle
 }
 
 // parseChar parses a single character.

--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -75,15 +75,19 @@ func (es *escapeSequence) convert(st *parseState) bool {
 		}
 		return true
 	case ansiControlSequence:
-		if mainc == 'm' {
+		switch {
+		case mainc == 'm':
 			st.style = csToStyle(st.style, es.parameter.String())
-		} else if mainc >= 'A' && mainc <= 'T' {
-			// Ignore.
-		} else {
-			if mainc >= 0x30 && mainc <= 0x3f {
-				es.parameter.WriteRune(mainc)
-				return true
+		case mainc == 'K':
+			if es.parameter.String() != "1" {
+				// Clear line.
+				st.eolStyle = st.style
 			}
+		case mainc >= 'A' && mainc <= 'T':
+			// Ignore.
+		case mainc >= '0' && mainc <= 'f':
+			es.parameter.WriteRune(mainc)
+			return true
 		}
 		es.state = ansiText
 		return true

--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -79,8 +79,10 @@ func (es *escapeSequence) convert(st *parseState) bool {
 		case mainc == 'm':
 			st.style = csToStyle(st.style, es.parameter.String())
 		case mainc == 'K':
-			if es.parameter.String() != "1" {
-				// Clear line.
+			// CSI 0 K or CSI K maintains the style after the newline
+			// (can change the background color of the line).
+			params := es.parameter.String()
+			if params == "" || params == "0" {
 				st.eolStyle = st.style
 			}
 		case mainc >= 'A' && mainc <= 'T':


### PR DESCRIPTION
ov(and other pagers) cannot be erased.
Actually, set the style from the end of the line.
This solves #650 .