### PR TITLE
OVStyle adds supported escape sequences

### DIFF
--- a/oviewer/content_test.go
+++ b/oviewer/content_test.go
@@ -346,47 +346,6 @@ func Test_StrToContentsStyle1(t *testing.T) {
 	}
 }
 
-func Test_StrToContentsStyle2(t *testing.T) {
-	type args struct {
-		str      string
-		tabWidth int
-	}
-	tests := []struct {
-		name string
-		args args
-		want contents
-	}{
-		{
-			name: "OverLine",
-			args: args{
-				str: "\x1B[53mol\x1B[m", tabWidth: 8,
-			},
-			want: contents{
-				{width: 1, style: tcell.StyleDefault.Underline(true), mainc: rune('o'), combc: nil},
-				{width: 1, style: tcell.StyleDefault.Underline(true), mainc: rune('l'), combc: nil},
-			},
-		},
-		{
-			name: "UnOverLine",
-			args: args{
-				str: "\x1B[53mo\x1B[m\x1B[55mu\x1B[m\x1B[53ml\x1B[m", tabWidth: 8,
-			},
-			want: contents{
-				{width: 1, style: tcell.StyleDefault.Underline(true), mainc: rune('o'), combc: nil},
-				{width: 1, style: tcell.StyleDefault.Underline(false), mainc: rune('u'), combc: nil},
-				{width: 1, style: tcell.StyleDefault.Underline(true), mainc: rune('l'), combc: nil},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := StrToContents(tt.args.str, tt.args.tabWidth); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseString() = %#v, want %#v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_StrToContentUnStyle(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -309,19 +309,21 @@ func parseSGR(paramStr string) OVStyle {
 			s.Background = "default"
 		case 53: // Overline On
 			s.OverLine = true
+			s.UnOverLine = false
 		case 55: // Overline Off
+			s.OverLine = false
 			s.UnOverLine = true
 		case 58: // UnderlineColor
-			// (not implemented). Increase index only.
-			_, i, err := parseSGRColor(sgr)
+			color, i, err := parseSGRColor(sgr)
 			if err != nil {
 				return s
 			}
 			index += i
+			s.UnderlineColor = color
 		case 59: // UnderlineColorDefault
-			// (not implemented).
+			s.UnderlineColor = "default"
 		case 73, 74, 75: // VerticalAlignment
-			// (not implemented).
+			s.VerticalAlignType = sgr.code - 73
 		case 90, 91, 92, 93, 94, 95, 96, 97: // Bright Foreground color
 			s.Foreground = colorName(sgr.code - 82)
 		case 100, 101, 102, 103, 104, 105, 106, 107: // Bright Background color

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -284,46 +284,6 @@ type Config struct {
 	Debug bool
 }
 
-// OVStyle represents a style in addition to the original style.
-type OVStyle struct {
-	// Background is a color name string.
-	Background string
-	// Foreground is a color name string.
-	Foreground string
-	// If true, add blink.
-	Blink bool
-	// If true, add bold.
-	Bold bool
-	// If true, add dim.
-	Dim bool
-	// If true, add italic.
-	Italic bool
-	// If true, add reverse.
-	Reverse bool
-	// If true, add underline.
-	Underline bool
-	// If true, add strike through.
-	StrikeThrough bool
-	// If true, add overline (not yet supported).
-	OverLine bool
-	// If true, sub blink.
-	UnBlink bool
-	// If true, sub bold.
-	UnBold bool
-	// If true, sub dim.
-	UnDim bool
-	// If true, sub italic.
-	UnItalic bool
-	// If true, sub reverse.
-	UnReverse bool
-	// If true, sub underline.
-	UnUnderline bool
-	// If true, sub strike through.
-	UnStrikeThrough bool
-	// if true, sub underline (not yet supported).
-	UnOverLine bool
-}
-
 var (
 	// MemoryLimit is a number that limits the chunks to load into memory.
 	MemoryLimit int
@@ -841,84 +801,6 @@ func (root *Root) debugMessage(msg string) {
 		return
 	}
 	log.Printf("%s:%s", root.Doc.FileName, msg)
-}
-
-// ToTcellStyle convert from ovStyle to tcell style.
-func ToTcellStyle(s OVStyle) tcell.Style {
-	style := tcell.StyleDefault
-	style = style.Background(tcell.GetColor(s.Background))
-	style = style.Foreground(tcell.GetColor(s.Foreground))
-	style = style.Blink(s.Blink)
-	style = style.Bold(s.Bold)
-	style = style.Dim(s.Dim)
-	style = style.Italic(s.Italic)
-	style = style.Reverse(s.Reverse)
-	style = style.Underline(s.Underline)
-	style = style.StrikeThrough(s.StrikeThrough)
-
-	return style
-}
-
-func applyStyle(style tcell.Style, s OVStyle) tcell.Style {
-	if s.Background != "" {
-		style = style.Background(tcell.GetColor(s.Background))
-	}
-	if s.Foreground != "" {
-		style = style.Foreground(tcell.GetColor(s.Foreground))
-	}
-	if s.Blink {
-		style = style.Blink(true)
-	}
-	if s.Bold {
-		style = style.Bold(true)
-	}
-	if s.Dim {
-		style = style.Dim(true)
-	}
-	if s.Italic {
-		style = style.Italic(true)
-	}
-	if s.Reverse {
-		style = style.Reverse(true)
-	}
-	if s.Underline {
-		style = style.Underline(true)
-	}
-	if s.StrikeThrough {
-		style = style.StrikeThrough(true)
-	}
-	if s.UnBlink {
-		style = style.Blink(false)
-	}
-	if s.UnBold {
-		style = style.Bold(false)
-	}
-	if s.UnDim {
-		style = style.Dim(false)
-	}
-	if s.UnItalic {
-		style = style.Italic(false)
-	}
-	if s.UnReverse {
-		style = style.Reverse(false)
-	}
-	if s.UnUnderline {
-		style = style.Underline(false)
-	}
-	if s.UnStrikeThrough {
-		style = style.StrikeThrough(false)
-	}
-	if s.OverLine {
-		// tcell does not support overline.
-		// style = style.OverLine(true)
-		style = style.Underline(true)
-	}
-	if s.UnOverLine {
-		// tcell does not support unOverline.
-		// style = style.UnOverLine(false)
-		style = style.Underline(false)
-	}
-	return style
 }
 
 // mergeGeneral overwrites a general structure with a struct.

--- a/oviewer/ovstyle.go
+++ b/oviewer/ovstyle.go
@@ -1,0 +1,140 @@
+package oviewer
+
+import "github.com/gdamore/tcell/v2"
+
+// OVStyle represents a style in addition to the original style.
+type OVStyle struct {
+	// Background is a color name string.
+	Background string
+	// Foreground is a color name string.
+	Foreground string
+	// UnderlineColor is a underline color name string.
+	UnderlineColor string
+	// UnderlineType is a underline type.
+	UnderlineType int
+	// VerticalAlignType is a vertical align type.
+	VerticalAlignType int
+	// If true, add blink.
+	Blink bool
+	// If true, add bold.
+	Bold bool
+	// If true, add dim.
+	Dim bool
+	// If true, add italic.
+	Italic bool
+	// If true, add reverse.
+	Reverse bool
+	// If true, add underline.
+	Underline bool
+	// If true, add strike through.
+	StrikeThrough bool
+	// If true, add overline (not yet supported).
+	OverLine bool
+	// If true, sub blink.
+	UnBlink bool
+	// If true, sub bold.
+	UnBold bool
+	// If true, sub dim.
+	UnDim bool
+	// If true, sub italic.
+	UnItalic bool
+	// If true, sub reverse.
+	UnReverse bool
+	// If true, sub underline.
+	UnUnderline bool
+	// If true, sub strike through.
+	UnStrikeThrough bool
+	// if true, sub overline (not yet supported).
+	UnOverLine bool
+}
+
+// ToTcellStyle convert from OVStyle to tcell style.
+func ToTcellStyle(s OVStyle) tcell.Style {
+	style := tcell.StyleDefault
+	style = style.Foreground(tcell.GetColor(s.Foreground))
+	style = style.Background(tcell.GetColor(s.Background))
+	style = style.Blink(s.Blink)
+	style = style.Bold(s.Bold)
+	style = style.Dim(s.Dim)
+	style = style.Italic(s.Italic)
+	style = style.Reverse(s.Reverse)
+	style = style.Underline(s.Underline)
+	style = style.StrikeThrough(s.StrikeThrough)
+	return style
+}
+
+// applyStyle applies the OVStyle to the tcell style.
+func applyStyle(style tcell.Style, s OVStyle) tcell.Style {
+	if s.Foreground != "" {
+		style = style.Foreground(tcell.GetColor(s.Foreground))
+	}
+	if s.Background != "" {
+		style = style.Background(tcell.GetColor(s.Background))
+	}
+	// tcell does not support underline color.
+	//if s.UnderlineColor != "" {
+	//	style = style.UnderlineColor(tcell.GetColor(s.UnderlineColor))
+	//}
+	// tcell does not support underline type.
+	//if s.UnderlineType != 0 {
+	//	Double,Curly,Dotted,Dashed
+	//}
+	// tcell does not support vertical align type.
+	//if s.VerticalAlignType != 0 {
+	//	Top,Middle,Bottom
+	//}
+
+	if s.Blink {
+		style = style.Blink(true)
+	}
+	if s.Bold {
+		style = style.Bold(true)
+	}
+	if s.Dim {
+		style = style.Dim(true)
+	}
+	if s.Italic {
+		style = style.Italic(true)
+	}
+	if s.Reverse {
+		style = style.Reverse(true)
+	}
+	if s.Underline {
+		style = style.Underline(true)
+	}
+	if s.StrikeThrough {
+		style = style.StrikeThrough(true)
+	}
+	// tcell does not support overline.
+	//if s.OverLine {
+	//	style = style.Overline(true)
+	//}
+
+	if s.UnBlink {
+		style = style.Blink(false)
+	}
+	if s.UnBold {
+		style = style.Bold(false)
+	}
+	if s.UnDim {
+		style = style.Dim(false)
+	}
+	if s.UnItalic {
+		style = style.Italic(false)
+	}
+	if s.UnReverse {
+		style = style.Reverse(false)
+	}
+	if s.UnUnderline {
+		style = style.Underline(false)
+	}
+	if s.UnStrikeThrough {
+		style = style.StrikeThrough(false)
+	}
+	// tcell does not support overline.
+	//if s.UnOverLine {
+	//	style = style.Overline(false)
+	//}
+
+	return style
+}


### PR DESCRIPTION
Add escape sequences that tcell does not support to OVStyle.
Separate ovstyle.go from oviewer.go.