### PR TITLE
Allow scrolling the last line to the top

### DIFF
--- a/oviewer/move_vertical.go
+++ b/oviewer/move_vertical.go
@@ -95,7 +95,12 @@ func (m *Document) limitMoveDown(lX int, lN int) {
 		return
 	}
 
-	tX, tN := m.bottomLineNum(m.BufEndNum()-1, m.height-lastLineMargin)
+	tX := 0
+	tN := m.BufEndNum() - (1 + m.firstLine())
+	if m.WrapMode {
+		tX, tN = m.bottomLineNum(m.BufEndNum()-1, m.height-lastLineMargin)
+	}
+
 	if lN < tN || (lN == tN && lX < tX) {
 		m.topLX = lX
 		m.topLN = lN

--- a/oviewer/move_vertical_test.go
+++ b/oviewer/move_vertical_test.go
@@ -578,7 +578,7 @@ func TestDocument_limitMoveDown(t *testing.T) {
 				lN: 2000,
 			},
 			wantLX: 0,
-			wantLN: 979,
+			wantLN: 1000,
 		},
 		{
 			name: "boundary",


### PR DESCRIPTION
Modified the behavior to allow the last line to be scrolled to the top of the screen when wrap mode is disabled.