### PR TITLE
Fix x start position to not be negative when moving to rightmost cursor

### DIFF
--- a/oviewer/move_lateral.go
+++ b/oviewer/move_lateral.go
@@ -42,7 +42,7 @@ func (m *Document) moveBeginLeft(scr SCR) {
 // moveEndRight moves to the right edge of the screen.
 func (m *Document) moveEndRight(scr SCR) {
 	x, cursor := maxLineSize(scr.lines)
-	m.x = x - validWidth(scr)
+	m.x = max(0, x-validWidth(scr))
 	m.columnCursor = cursor
 }
 


### PR DESCRIPTION
Corrected the logic to ensure the x start position does not become negative when moving the cursor to the rightmost position.