### PR TITLE
Adjust x position if search term is hidden

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -198,13 +198,13 @@ func (root *Root) watchControl() {
 func (root *Root) searchGo(ctx context.Context, lN int, searcher Searcher) {
 	root.resetSelect()
 	root.Doc.lastSearchLN = lN
-	x := root.searchXPos(lN, searcher)
+	start, end := root.searchXPos(lN, searcher)
 	if root.Doc.jumpTargetSection {
-		root.Doc.searchGoSection(ctx, lN, x)
+		root.Doc.searchGoSection(ctx, lN, start, end)
 		return
 	}
 	root.debugMessage(fmt.Sprintf("searchGo:%d->%d", root.Doc.topLN, lN))
-	root.Doc.searchGoTo(lN, x)
+	root.Doc.searchGoTo(lN, start, end)
 }
 
 // goLine will move to the specified line.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -216,13 +216,13 @@ func (root *Root) searchPosition(str string) [][]int {
 }
 
 // searchXPos returns the x position of the first match.
-func (root *Root) searchXPos(lineNum int, searcher Searcher) int {
+func (root *Root) searchXPos(lineNum int, searcher Searcher) (int, int) {
 	line := root.Doc.getLineC(lineNum)
 	indexes := searcher.FindAll(line.str)
 	if len(indexes) == 0 {
-		return 0
+		return 0, 0
 	}
-	return line.pos.x(indexes[0][0])
+	return line.pos.x(indexes[0][0]), line.pos.x(indexes[0][1])
 }
 
 // searchPositionReg returns an array of the beginning and end of the string

--- a/oviewer/search_move.go
+++ b/oviewer/search_move.go
@@ -7,8 +7,8 @@ import (
 // searchGoTo moves to the specified line and position after searching.
 // Go to the specified line +root.Doc.JumpTarget Go to.
 // If the search term is off screen, move until the search term is visible.
-func (m *Document) searchGoTo(lN int, x int) {
-	m.searchGoX(x)
+func (m *Document) searchGoTo(lN int, start int, end int) {
+	m.searchGoX(start, end)
 	m.showGotoF = true
 	m.topLN = lN - m.firstLine()
 	m.moveYUp(m.jumpTargetHeight)
@@ -21,8 +21,8 @@ func (m *Document) bottomJumpTarget() int {
 
 // searchGoSection will go to the section with the matching term after searching.
 // Move the JumpTarget so that it can be seen from the beginning of the section.
-func (m *Document) searchGoSection(ctx context.Context, lN int, x int) {
-	m.searchGoX(x)
+func (m *Document) searchGoSection(ctx context.Context, lN int, start int, end int) {
+	m.searchGoX(start, end)
 
 	sN, err := m.prevSection(ctx, lN)
 	if err != nil {
@@ -56,18 +56,21 @@ func (m *Document) searchGoSection(ctx context.Context, lN int, x int) {
 }
 
 // searchGoX moves to the specified x position.
-func (m *Document) searchGoX(x int) {
+func (m *Document) searchGoX(start int, end int) {
 	if m.width == 0 {
 		return
 	}
 	m.topLX = 0
 	// If the search term is outside the height of the screen when in WrapMode.
-	if nTh := x / m.width; nTh > m.height {
+	if nTh := start / m.width; nTh > m.height {
 		m.topLX = nTh * m.width
 	}
 
 	// If the search term is outside the width of the screen when in NoWrapMode.
-	if x < m.x || x > m.x+m.width-1 {
-		m.x = x
+	if start < m.x {
+		m.x = 0
+	}
+	if end > m.x+m.width-1 {
+		m.x = max(end-(m.width-columnMargin), 0)
 	}
 }


### PR DESCRIPTION
Fixed the issue where the x position was adjustedif the search term was hidden. If the search term was at the edge, the end position of the search term now scrolls to the right edge.