### PR TITLE
feat: Add styled terminal output with toggleable raw text option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/noborus/guesswidth v0.4.0
+	github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/noborus/guesswidth v0.4.0
-	github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff
+	github.com/noborus/tcellansi v0.0.0-20250320075053-376e9cb3c42b
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/noborus/guesswidth v0.4.0 h1:+PPh+Z+GM4mKmVrhYR4lpjeyBuLMSVo2arM+VErdHIc=
 github.com/noborus/guesswidth v0.4.0/go.mod h1:ghA6uh9RcK+uSmaDDmBMj/tRZ3BSpspDP6DMF5Xk3bc=
+github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff h1:XbxrxKjGtOpa5weBT/JWEIj8RHpe+nBQWB7dOdgJVwE=
+github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff/go.mod h1:SwO30BLurbvO5kbAF5uC6YL316Z6UUolTvrEzrGNXxg=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/noborus/guesswidth v0.4.0 h1:+PPh+Z+GM4mKmVrhYR4lpjeyBuLMSVo2arM+VErdHIc=
 github.com/noborus/guesswidth v0.4.0/go.mod h1:ghA6uh9RcK+uSmaDDmBMj/tRZ3BSpspDP6DMF5Xk3bc=
-github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff h1:XbxrxKjGtOpa5weBT/JWEIj8RHpe+nBQWB7dOdgJVwE=
-github.com/noborus/tcellansi v0.0.0-20250315023647-d39fa6c149ff/go.mod h1:SwO30BLurbvO5kbAF5uC6YL316Z6UUolTvrEzrGNXxg=
+github.com/noborus/tcellansi v0.0.0-20250320075053-376e9cb3c42b h1:5EpdRpG4A6J1vK/vwVLczm3l1hB4KwmlqHdsFgfTffc=
+github.com/noborus/tcellansi v0.0.0-20250320075053-376e9cb3c42b/go.mod h1:uZyUH8CuoepBfZgDzh8xV3z1sZFAw97hN8otIuZT5jA=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=

--- a/main.go
+++ b/main.go
@@ -210,12 +210,7 @@ func RunOviewer(args []string) error {
 		return err
 	}
 
-	if ov.IsWriteOriginal {
-		ov.WriteOriginal()
-	}
-	if ov.Debug {
-		ov.WriteLog()
-	}
+	ov.OutputOnExit()
 	return nil
 }
 
@@ -240,12 +235,8 @@ func ExecCommand(args []string) error {
 		return err
 	}
 
-	if ov.IsWriteOriginal {
-		ov.WriteOriginal()
-	}
-	if ov.Debug {
-		ov.WriteLog()
-	}
+	ov.OutputOnExit()
+
 	return nil
 }
 
@@ -542,7 +533,7 @@ func init() {
 	_ = viper.BindPFlag("QuitSmall", rootCmd.PersistentFlags().Lookup("quit-if-one-screen"))
 
 	rootCmd.PersistentFlags().BoolP("exit-write", "X", false, "output the current screen when exiting")
-	_ = viper.BindPFlag("IsWriteOriginal", rootCmd.PersistentFlags().Lookup("exit-write"))
+	_ = viper.BindPFlag("IsScreenConent", rootCmd.PersistentFlags().Lookup("exit-write"))
 
 	rootCmd.PersistentFlags().IntP("exit-write-before", "b", 0, "number before the current lines when exiting")
 	_ = viper.BindPFlag("BeforeWriteOriginal", rootCmd.PersistentFlags().Lookup("exit-write-before"))

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -574,7 +574,7 @@ func (root *Root) setWriteBA(ctx context.Context, input string) {
 	root.BeforeWriteOriginal = before
 	root.AfterWriteOriginal = after
 	root.debugMessage(fmt.Sprintf("Before:After:%d:%d", root.BeforeWriteOriginal, root.AfterWriteOriginal))
-	root.IsWriteOriginal = true
+	root.IsWriteOnExit = true
 	root.Quit(ctx)
 }
 
@@ -840,13 +840,21 @@ func (root *Root) Cancel(context.Context) {
 	root.Doc.FollowMode = false
 }
 
+// toggleWriteOriginal toggles the write flag.
+func (root *Root) toggleWriteOriginal(context.Context) {
+	root.IsWriteOriginal = !root.IsWriteOriginal
+	root.setMessagef("Set WriteOriginal %t", root.IsWriteOriginal)
+}
+
 // WriteQuit sets the write flag and executes a quit event.
 func (root *Root) WriteQuit(ctx context.Context) {
-	root.IsWriteOriginal = true
+	root.IsWriteOnExit = true
 	if root.Doc.HideOtherSection && root.AfterWriteOriginal == 0 {
 		// hide other section.
 		root.AfterWriteOriginal = root.bottomSectionLN(ctx)
 	}
+	root.OnExit = root.ScreenContent()
+
 	root.Quit(ctx)
 }
 

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1286,8 +1286,8 @@ func TestRoot_setWriteBA(t *testing.T) {
 			root := rootFileReadHelper(t, tt.fields.fileName)
 			ctx := context.Background()
 			root.setWriteBA(ctx, tt.args.input)
-			if root.IsWriteOriginal != tt.want {
-				t.Errorf("setWriteBA() = %v, want %v", root.IsWriteOriginal, tt.want)
+			if root.IsWriteOnExit != tt.want {
+				t.Errorf("setWriteBA() = %v, want %v", root.IsWriteOnExit, tt.want)
 			}
 		})
 	}

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -69,6 +69,9 @@ type Config struct {
 	MemoryLimitFile int
 	// DisableMouse indicates whether mouse support is disabled.
 	DisableMouse bool
+
+	// IsWriteOnExit indicates whether to write the current screen on exit.
+	IsWriteOnExit bool
 	// IsWriteOriginal indicates whether the current screen should be written on quit.
 	IsWriteOriginal bool
 	// QuitSmall indicates whether to quit if the output fits on one screen.

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -50,6 +50,7 @@ const (
 	actionShrinkColumn   = "shrink_column"
 	actionRightAlign     = "right_align"
 	actionRuler          = "toggle_ruler"
+	actionWriteOriginal  = "write_original"
 
 	// Move actions.
 	actionMoveDown       = "down"
@@ -148,6 +149,7 @@ func (root *Root) handlers() map[string]func(context.Context) {
 		actionShrinkColumn:   root.toggleShrinkColumn,
 		actionRightAlign:     root.toggleRightAlign,
 		actionRuler:          root.toggleRuler,
+		actionWriteOriginal:  root.toggleWriteOriginal,
 
 		// Move actions.
 		actionMoveDown:       root.moveDownOne,
@@ -250,6 +252,7 @@ func defaultKeyBinds() KeyBind {
 		actionShrinkColumn:   {"s"},
 		actionRightAlign:     {"alt+a"},
 		actionRuler:          {"alt+shift+F9"},
+		actionWriteOriginal:  {"alt+shift+F8"},
 
 		// Move actions.
 		actionMoveDown:       {"Enter", "Down", "ctrl+N"},
@@ -317,6 +320,7 @@ func (k KeyBind) String() string {
 	k.writeKeyBind(&b, actionCancel, "cancel")
 	k.writeKeyBind(&b, actionWriteExit, "output screen and quit")
 	k.writeKeyBind(&b, actionWriteBA, "set output screen and quit")
+	k.writeKeyBind(&b, actionWriteOriginal, "set output original screen and quit")
 	k.writeKeyBind(&b, actionSuspend, "suspend")
 	k.writeKeyBind(&b, actionHelp, "display help screen")
 	k.writeKeyBind(&b, actionLogDoc, "display log screen")

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -687,6 +687,7 @@ func (root *Root) sendNextBackSearch(context.Context) {
 // This is for calling Search from the outside.
 // Normally, the event is executed from Confirm.
 func (root *Root) Search(str string) {
+	root.Pattern = str
 	root.sendSearch(str)
 }
 


### PR DESCRIPTION
This commit modifies the terminal output behavior of the pager. Previously, the terminal output was limited to the original text content. Now, it outputs the processed content displayed on the pager, including features like search highlights.

Key changes:
- Added functionality to toggle between outputting the original text and the processed screen content.
- Implemented a dummy screen rendering for cases where the content fits within the terminal, ensuring consistent processing.
- Changed the default behavior to output the processed screen content. Users can switch to the original text output via a toggle key or configuration.

Notes:
- Users who prefer the original text output must update their configuration.
- The output now uses ANSI escape sequences for styling. Terminals that do not support certain sequences may display content incorrectly.

Closes #684.