### PR TITLE
Distinguish unset and default values for view-mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,21 +95,6 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 		if completion != "" {
 			return Completion(cmd, completion)
 		}
-		// Set the caption from the environment variable.
-		if config.General.Caption == "" {
-			config.General.Caption = viper.GetString("CAPTION")
-		}
-
-		// Actually tabs when "\t" is specified as an option.
-		if config.General.ColumnDelimiter == "\\t" {
-			config.General.ColumnDelimiter = "\t"
-		}
-
-		// SectionHeader is enabled if SectionHeaderNum is greater than 0.
-		if config.General.SectionHeaderNum > 0 {
-			config.General.SectionHeader = true
-		}
-
 		// Set a converter by specifying flag.
 		if alignF {
 			config.General.Converter = "align"

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -449,13 +449,13 @@ func getTty() (*os.File, error) {
 // setViewMode switches to the preset display mode.
 // Set header lines and columnMode together.
 func (root *Root) setViewMode(ctx context.Context, modeName string) {
-	c, err := root.modeConfig(modeName)
+	general, err := root.setModeConfig(modeName)
 	if err != nil {
 		root.setMessage(err.Error())
 		return
 	}
 	m := root.Doc
-	m.general = mergeGeneral(m.general, c)
+	m.general = finalizeGeneral(general)
 	m.conv = m.converterType(m.general.Converter)
 	m.regexpCompile()
 	m.ClearCache()
@@ -467,17 +467,14 @@ func (root *Root) setViewMode(ctx context.Context, modeName string) {
 	root.setMessagef("Set mode %s", modeName)
 }
 
-// modeConfig returns the configuration of the specified mode.
-func (root *Root) modeConfig(modeName string) (general, error) {
-	if modeName == nameGeneral {
-		return root.General, nil
-	}
-
-	c, ok := root.Config.Mode[modeName]
+// setModeConfig returns the configuration of the specified mode.
+func (root *Root) setModeConfig(modeName string) (general, error) {
+	modeConfig, ok := root.Config.Mode[modeName]
 	if !ok {
 		return general{}, fmt.Errorf("%s mode not found", modeName)
 	}
-	return c, nil
+	config := setModeConfig(root.Doc.general, modeConfig)
+	return config, nil
 }
 
 // setConverter sets the converter type.

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1294,6 +1294,12 @@ func TestRoot_setWriteBA(t *testing.T) {
 }
 
 func TestRoot_modeConfig(t *testing.T) {
+	modeConfig := map[string]modeConfig{
+		"a": {},
+		"b": {
+			TabWidth: intPtr(4),
+		},
+	}
 	type args struct {
 		modeName string
 	}
@@ -1316,7 +1322,11 @@ func TestRoot_modeConfig(t *testing.T) {
 			args: args{
 				modeName: nameGeneral,
 			},
-			want:    general{},
+			want: general{
+				Converter:      "es",
+				TabWidth:       8,
+				MarkStyleWidth: 1,
+			},
 			wantErr: false,
 		},
 		{
@@ -1324,27 +1334,39 @@ func TestRoot_modeConfig(t *testing.T) {
 			args: args{
 				modeName: "a",
 			},
-			want:    general{},
+			want: general{
+				Converter:      "es",
+				TabWidth:       8,
+				MarkStyleWidth: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "testModeConfig b",
+			args: args{
+				modeName: "b",
+			},
+			want: general{
+				Converter:      "es",
+				TabWidth:       4,
+				MarkStyleWidth: 1,
+			},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootHelper(t)
-			root.Config = Config{
-				General: general{},
-				Mode: map[string]modeConfig{
-					"a": {},
-					"b": {},
-				},
-			}
+			config := NewConfig()
+			config.Mode = modeConfig
+			root.SetConfig(config)
 			got, err := root.setModeConfig(tt.args.modeName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Root.modeConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Root.modeConfig() = %v, want %v", got, tt.want)
+				t.Errorf("Root.modeConfig() = \n%#v, want\n%#v", got, tt.want)
 			}
 		})
 	}

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1333,12 +1333,12 @@ func TestRoot_modeConfig(t *testing.T) {
 			root := rootHelper(t)
 			root.Config = Config{
 				General: general{},
-				Mode: map[string]general{
+				Mode: map[string]modeConfig{
 					"a": {},
 					"b": {},
 				},
 			}
-			got, err := root.modeConfig(tt.args.modeName)
+			got, err := root.setModeConfig(tt.args.modeName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Root.modeConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -176,6 +176,7 @@ func NewConfig() Config {
 			Bold:       true,
 		},
 		General: general{
+			Converter:      "es",
 			TabWidth:       8,
 			MarkStyleWidth: 1,
 		},

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -5,7 +5,7 @@ type Config struct {
 	// KeyBinding
 	Keybind map[string][]string
 	// Mode represents the operation of the customized mode.
-	Mode map[string]general
+	Mode map[string]modeConfig
 	// ViewMode represents the view mode.
 	// ViewMode sets several settings together and can be easily switched.
 	ViewMode string

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -593,12 +593,12 @@ func setModeConfig(src general, dst modeConfig) general {
 
 // generateMode generates a view mode configuration from a general structure.
 func generateMode(general general) modeConfig {
-	configGeneral := modeConfig{}
+	mode := modeConfig{}
 
 	srcVal := reflect.ValueOf(&general).Elem()
 	srcType := srcVal.Type()
 
-	dstVal := reflect.ValueOf(&configGeneral).Elem()
+	dstVal := reflect.ValueOf(&mode).Elem()
 
 	for i := 0; i < srcVal.NumField(); i++ {
 		srcField := srcVal.Field(i)
@@ -612,7 +612,7 @@ func generateMode(general general) modeConfig {
 			dstField.Set(srcField)
 		}
 	}
-	return configGeneral
+	return mode
 }
 
 // SetWatcher sets file monitoring.

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -796,7 +796,7 @@ func TestRoot_setCaption(t *testing.T) {
 
 func TestRoot_setViewModeConfig(t *testing.T) {
 	type fields struct {
-		viewMode map[string]general
+		viewMode map[string]modeConfig
 	}
 	tests := []struct {
 		name     string
@@ -806,7 +806,7 @@ func TestRoot_setViewModeConfig(t *testing.T) {
 		{
 			name: "test1",
 			fields: fields{
-				viewMode: map[string]general{
+				viewMode: map[string]modeConfig{
 					"view1": {},
 				},
 			},
@@ -878,3 +878,32 @@ func TestRoot_prepareRun(t *testing.T) {
 		})
 	}
 }
+func TestSetConfigGeneral(t *testing.T) {
+	src := general{
+		TabWidth:      8,
+		Header:        2,
+		AlternateRows: false,
+	}
+
+	dst := modeConfig{
+		TabWidth:      intPtr(4),
+		Header:        nil, // nil の場合は src の値を保持
+		AlternateRows: boolPtr(true),
+	}
+
+	result := setModeConfig(src, dst)
+
+	if result.TabWidth != 4 {
+		t.Errorf("Expected TabWidth to be 4, got %d", result.TabWidth)
+	}
+	if result.Header != 2 {
+		t.Errorf("Expected Header to remain 2, got %d", result.Header)
+	}
+	if result.AlternateRows != true {
+		t.Errorf("Expected AlternateRows to be true, got %v", result.AlternateRows)
+	}
+}
+
+func intPtr(i int) *int       { return &i }
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
This commit fixes an issue where unset and default values for view-mode could not be distinguished.
To address this, the `general` field in the view-mode configuration has been changed to use a pointer type.

Fixes #735