### PR TITLE
make minStartX configurable with default value 0

### DIFF
--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -14,6 +14,8 @@ type Config struct {
 
 	// Prompt is the prompt setting.
 	Prompt OVPromptConfig
+	// MinStartX is the minimum value of the start position.
+	MinStartX int
 
 	// StyleColumnRainbow  is the style that applies to the column rainbow color highlight.
 	StyleColumnRainbow []OVStyle

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -368,15 +368,15 @@ func NewOviewer(docs ...*Document) (*Root, error) {
 		return nil, ErrNotFound
 	}
 	root := &Root{
-		minStartX: MinStartX,
-		settings:  NewRunTimeSettings(),
+		minStartX:      MinStartX,
+		settings:       NewRunTimeSettings(),
+		Config:         NewConfig(),
+		keyConfig:      cbind.NewConfiguration(),
+		inputKeyConfig: cbind.NewConfiguration(),
+		input:          NewInput(),
 	}
-	root.Config = NewConfig()
-	root.keyConfig = cbind.NewConfiguration()
-	root.inputKeyConfig = cbind.NewConfiguration()
 	root.DocList = append(root.DocList, docs...)
 	root.Doc = root.DocList[0]
-	root.input = NewInput()
 
 	screen, err := tcellNewScreen()
 	if err != nil {
@@ -505,7 +505,8 @@ func (root *Root) SetConfig(config Config) {
 
 	// Set the follow mode for all documents.
 	root.FollowAll = root.settings.FollowAll
-
+	// Set the minimum start position of x.
+	root.minStartX = config.MinStartX
 	// Set the caption from the environment variable.
 	if root.settings.Caption == "" {
 		root.settings.Caption = viper.GetString("CAPTION")


### PR DESCRIPTION
Implemented a fix for issue #739 by adding a configurable minStartX to set the minimum starting position (x) for document display.
The default value is set to 0.