### PR TITLE
Change Style config to general/Style/

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -39,64 +39,64 @@ General:
   WrapMode: true
   ColumnDelimiter: ","
   MarkStyleWidth: 1
-
-# Style
-# String of the color name: Foreground, Background, UnderlineColor
-# Boolean: Bold, Blink, Dim, Italic, Underline
-# Number: UnderlineStyle
-StyleAlternate:
-  Background: "gray"
-StyleHeader:
-  Bold: true
-StyleBody:
-  # Add appropriate styles here
-StyleOverStrike:
-  Bold: true
-StyleOverLine:
-  Underline: true
-StyleLineNumber:
-  Bold: true
-StyleSearchHighlight:
-  Reverse: true
-StyleColumnHighlight:
-  Reverse: true
-StyleMarkLine:
-  Background: "darkgoldenrod"
-StyleSectionLine:
-  Background: "slateblue"
-StyleVerticalHeader:
-  # Add appropriate styles here
-StyleRuler:
-  Background: "#333333"
-  Foreground: "#CCCCCC"
-  Bold: true
-StyleHeaderBorder:
-  # Add appropriate styles here
-  # UnderlineStyle: 2
-StyleSectionHeaderBorder:
-  # Add appropriate styles here
-  # Underline: true
-  # UnderlineColor: "red"
-StyleVerticalHeaderBorder:
-  Background: "#c0c0c0"
-StyleMultiColorHighlight:
-  - Foreground: "red"
-  - Foreground: "aqua"
-  - Foreground: "yellow"
-  - Foreground: "fuchsia"
-  - Foreground: "lime"
-  - Foreground: "blue"
-  - Foreground: "grey"
-StyleColumnRainbow:
-  - Foreground: "white"
-  - Foreground: "crimson"
-  - Foreground: "aqua"
-  - Foreground: "lightsalmon"
-  - Foreground: "lime"
-  - Foreground: "blue"
-  - Foreground: "yellowgreen"
-StyleJumpTargetLine:
-  Underline: true
+  # Style
+  # String of the color name: Foreground, Background, UnderlineColor
+  # Boolean: Bold, Blink, Dim, Italic, Underline
+  # Number: UnderlineStyle
+  Style:
+    Alternate:
+        Background: "gray"
+    Header:
+        Bold: true
+    Body:
+        # Add appropriate styles here
+    OverStrike:
+        Bold: true
+    OverLine:
+        Underline: true
+    LineNumber:
+        Bold: true
+    SearchHighlight:
+        Reverse: true
+    ColumnHighlight:
+        Reverse: true
+    MarkLine:
+        Background: "darkgoldenrod"
+    SectionLine:
+        Background: "slateblue"
+    VerticalHeader:
+        # Add appropriate styles here
+    Ruler:
+        Background: "#333333"
+        Foreground: "#CCCCCC"
+        Bold: true
+    HeaderBorder:
+        # Add appropriate styles here
+        # UnderlineStyle: 2
+    SectionHeaderBorder:
+        # Add appropriate styles here
+        # Underline: true
+        # UnderlineColor: "red"
+    VerticalHeaderBorder:
+        Background: "#c0c0c0"
+    MultiColorHighlight:
+        - Foreground: "red"
+        - Foreground: "aqua"
+        - Foreground: "yellow"
+        - Foreground: "fuchsia"
+        - Foreground: "lime"
+        - Foreground: "blue"
+        - Foreground: "grey"
+    ColumnRainbow:
+        - Foreground: "white"
+        - Foreground: "crimson"
+        - Foreground: "aqua"
+        - Foreground: "lightsalmon"
+        - Foreground: "lime"
+        - Foreground: "blue"
+        - Foreground: "yellowgreen"
+    JumpTargetLine:
+        Underline: true
 
 # Keybind
 # Special key

--- a/ov.yaml
+++ b/ov.yaml
@@ -39,63 +39,64 @@ General:
   ColumnDelimiter: ","
   MarkStyleWidth: 1
 #  SectionDelimiter: "^#"
+  # Style
+  # String of the color name: Foreground, Background, UnderlineColor
+  # Boolean: Bold, Blink, Dim, Italic, Underline
+  # Number: UnderlineStyle
+  Style:
+    Alternate:
+      Background: "gray"
+    Header:
+      Bold: true
+    Body:
+      # Add appropriate styles here
+    LineNumber:
+      Bold: true
+      StyleSearchHighlight:
+      Reverse: true
+    ColumnHighlight:
+      Reverse: true
+    MarkLine:
+      Background: "darkgoldenrod"
+    SectionLine:
+      Background: "slateblue"
+    VerticalHeader:
+    # Add appropriate styles here
+    Ruler:
+      Background: "#333333"
+      Foreground: "#CCCCCC"
+      Bold: true
+    HeaderBorder:
+    # Add appropriate styles here
+    # UnderlineStyle: 2
+    SectionHeaderBorder:
+    # Add appropriate styles here
+    # Underline: true
+    # UnderlineColor: "red"
+    VerticalHeaderBorder:
+      Background: "#c0c0c0"
+    MultiColorHighlight:
+      - Foreground: "red"
+      - Foreground: "aqua"
+      - Foreground: "yellow"
+      - Foreground: "fuchsia"
+      - Foreground: "lime"
+      - Foreground: "blue"
+      - Foreground: "grey"
+    ColumnRainbow:
+      - Foreground: "white"
+      - Foreground: "crimson"
+      - Foreground: "aqua"
+      - Foreground: "lightsalmon"
+      - Foreground: "lime"
+      - Foreground: "blue"
+      - Foreground: "yellowgreen"
+    JumpTargetLine:
+      Underline: true
 
-# Style
-# String of the color name: Foreground, Background, UnderlineColor
-# Boolean: Bold, Blink, Dim, Italic, Underline
-# Number: UnderlineStyle
-StyleAlternate:
-  Background: "gray"
-StyleHeader:
-  Bold: true
-StyleBody:
-  # Add appropriate styles here
 StyleOverStrike:
   Bold: true
 StyleOverLine:
-  Underline: true
-StyleLineNumber:
-  Bold: true
-StyleSearchHighlight:
-  Reverse: true
-StyleColumnHighlight:
-  Reverse: true
-StyleMarkLine:
-  Background: "darkgoldenrod"
-StyleSectionLine:
-  Background: "slateblue"
-StyleVerticalHeader:
-  # Add appropriate styles here
-StyleRuler:
-  Background: "#333333"
-  Foreground: "#CCCCCC"
-  Bold: true
-StyleHeaderBorder:
-  # Add appropriate styles here
-  # UnderlineStyle: 2
-StyleSectionHeaderBorder:
-  # Add appropriate styles here
-  # Underline: true
-  # UnderlineColor: "red"
-StyleVerticalHeaderBorder:
-  Background: "#c0c0c0"
-StyleMultiColorHighlight:
-  - Foreground: "red"
-  - Foreground: "aqua"
-  - Foreground: "yellow"
-  - Foreground: "fuchsia"
-  - Foreground: "lime"
-  - Foreground: "blue"
-  - Foreground: "grey"
-StyleColumnRainbow:
-  - Foreground: "white"
-  - Foreground: "crimson"
-  - Foreground: "aqua"
-  - Foreground: "lightsalmon"
-  - Foreground: "lime"
-  - Foreground: "blue"
-  - Foreground: "yellowgreen"
-StyleJumpTargetLine:
   Underline: true
 
 # Keybind

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1897,31 +1897,31 @@ func TestRoot_format(t *testing.T) {
 			name:        "testAlignFormat",
 			converter:   convRaw,
 			formatFunc:  func(ctx context.Context) { root.alignFormat(ctx) },
-			wantMessage: "Set align mode",
+			wantMessage: "Set align converter",
 		},
 		{
 			name:        "testAlignFormatAlreadySet",
 			converter:   convAlign,
 			formatFunc:  func(ctx context.Context) { root.alignFormat(ctx) },
-			wantMessage: "Set es mode",
+			wantMessage: "Set es converter",
 		},
 		{
 			name:        "testRawFormat",
 			converter:   convAlign,
 			formatFunc:  func(ctx context.Context) { root.rawFormat(ctx) },
-			wantMessage: "Set raw mode",
+			wantMessage: "Set raw converter",
 		},
 		{
 			name:        "testRawFormatAlreadySet",
 			converter:   convRaw,
 			formatFunc:  func(ctx context.Context) { root.rawFormat(ctx) },
-			wantMessage: "Set es mode",
+			wantMessage: "Set es converter",
 		},
 		{
 			name:        "testEsFormat",
 			converter:   "",
 			formatFunc:  func(ctx context.Context) { root.esFormat(ctx) },
-			wantMessage: "Set es mode",
+			wantMessage: "Set es converter",
 		},
 	}
 	for _, tt := range tests {

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -17,45 +17,10 @@ type Config struct {
 	// MinStartX is the minimum value of the start position.
 	MinStartX int
 
-	// StyleColumnRainbow  is the style that applies to the column rainbow color highlight.
-	StyleColumnRainbow []OVStyle
-	// StyleMultiColorHighlight is the style that applies to the multi color highlight.
-	StyleMultiColorHighlight []OVStyle
-	// StyleHeader is the style that applies to the header.
-	StyleHeader OVStyle
-	// StyleBody is the style that applies to the body.
-	StyleBody OVStyle
-	// StyleLineNumber is a style that applies line number.
-	StyleLineNumber OVStyle
-	// StyleSearchHighlight is the style that applies to the search highlight.
-	StyleSearchHighlight OVStyle
-	// StyleColumnHighlight is the style that applies to the column highlight.
-	StyleColumnHighlight OVStyle
-	// StyleMarkLine is a style that marked line.
-	StyleMarkLine OVStyle
-	// StyleSectionLine is a style that section delimiter line.
-	StyleSectionLine OVStyle
-	// StyleVerticalHeader is a style that applies to the vertical header.
-	StyleVerticalHeader OVStyle
-	// StyleJumpTargetLine is the line that displays the search results.
-	StyleJumpTargetLine OVStyle
-	// StyleAlternate is a style that applies line by line.
-	StyleAlternate OVStyle
 	// StyleOverStrike is a style that applies to overstrike.
 	StyleOverStrike OVStyle
 	// StyleOverLine is a style that applies to overstrike underlines.
 	StyleOverLine OVStyle
-	// StyleRuler is a style that applies to the ruler.
-	StyleRuler OVStyle
-	// StyleHeaderBorder is the style that applies to the boundary line of the header.
-	// The boundary line of the header refers to the visual separator between the header and the rest of the content.
-	StyleHeaderBorder OVStyle
-	// StyleSectionHeaderBorder is the style that applies to the boundary line of the section header.
-	// The boundary line of the section header is the line that separates different sections in the header.
-	StyleSectionHeaderBorder OVStyle
-	// StyleVerticalHeaderBorder is the style that applies to the boundary character of the vertical header.
-	// The boundary character of the vertical header refers to the visual separator that delineates the vertical header from the rest of the content.
-	StyleVerticalHeaderBorder OVStyle
 
 	// GeneralConfig is the general setting.
 	General General
@@ -97,6 +62,8 @@ type Config struct {
 	DisableColumnCycle bool
 	// Debug indicates whether to enable debug output.
 	Debug bool
+	// deprecatedStyleConfig is the old style setting.
+	deprecatedStyleConfig `yaml:",inline" mapstructure:",squash"`
 }
 
 // General is the general configuration.
@@ -169,6 +136,8 @@ type General struct {
 	SectionHeader *bool
 	// HideOtherSection is whether to hide other sections.
 	HideOtherSection *bool
+	// Style is the style setting.
+	Style StyleConfig
 }
 
 // OVPromptConfigNormal is the normal prompt setting.
@@ -192,63 +161,6 @@ func NewConfig() Config {
 	return Config{
 		MemoryLimit:     -1,
 		MemoryLimitFile: 100,
-		StyleHeader: OVStyle{
-			Bold: true,
-		},
-		StyleAlternate: OVStyle{
-			Background: "gray",
-		},
-		StyleOverStrike: OVStyle{
-			Bold: true,
-		},
-		StyleOverLine: OVStyle{
-			Underline: true,
-		},
-		StyleLineNumber: OVStyle{
-			Bold: true,
-		},
-		StyleSearchHighlight: OVStyle{
-			Reverse: true,
-		},
-		StyleColumnHighlight: OVStyle{
-			Reverse: true,
-		},
-		StyleMarkLine: OVStyle{
-			Background: "darkgoldenrod",
-		},
-		StyleSectionLine: OVStyle{
-			Background: "slateblue",
-		},
-		StyleVerticalHeader: OVStyle{},
-		StyleVerticalHeaderBorder: OVStyle{
-			Background: "#c0c0c0",
-		},
-		StyleMultiColorHighlight: []OVStyle{
-			{Foreground: "red"},
-			{Foreground: "aqua"},
-			{Foreground: "yellow"},
-			{Foreground: "fuchsia"},
-			{Foreground: "lime"},
-			{Foreground: "blue"},
-			{Foreground: "grey"},
-		},
-		StyleColumnRainbow: []OVStyle{
-			{Foreground: "white"},
-			{Foreground: "crimson"},
-			{Foreground: "aqua"},
-			{Foreground: "lightsalmon"},
-			{Foreground: "lime"},
-			{Foreground: "blue"},
-			{Foreground: "yellowgreen"},
-		},
-		StyleJumpTargetLine: OVStyle{
-			Underline: true,
-		},
-		StyleRuler: OVStyle{
-			Background: "#333333",
-			Foreground: "#CCCCCC",
-			Bold:       true,
-		},
 		Prompt: OVPromptConfig{
 			Normal: OVPromptConfigNormal{
 				ShowFilename:   true,
@@ -257,4 +169,95 @@ func NewConfig() Config {
 			},
 		},
 	}
+}
+
+// StyleConfig is the style setting.
+type StyleConfig struct {
+	// ColumnRainbow is the style that applies to the column rainbow color highlight.
+	ColumnRainbow *[]OVStyle
+	// MultiColorHighlight is the style that applies to the multi color highlight.
+	MultiColorHighlight *[]OVStyle
+	// Header is the style that applies to the header.
+	Header *OVStyle
+	// Body is the style that applies to the body.
+	Body *OVStyle
+	// LineNumber is a style that applies line number.
+	LineNumber *OVStyle
+	// SearchHighlight is the style that applies to the search highlight.
+	SearchHighlight *OVStyle
+	// ColumnHighlight is the style that applies to the column highlight.
+	ColumnHighlight *OVStyle
+	// MarkLine is a style that marked line.
+	MarkLine *OVStyle
+	// SectionLine is a style that section delimiter line.
+	SectionLine *OVStyle
+	// VerticalHeader is a style that applies to the vertical header.
+	VerticalHeader *OVStyle
+	// JumpTargetLine is the line that displays the search results.
+	JumpTargetLine *OVStyle
+	// Alternate is a style that applies line by line.
+	Alternate *OVStyle
+	// Ruler is a style that applies to the ruler.
+	Ruler *OVStyle
+	// HeaderBorder is the style that applies to the boundary line of the header.
+	// The boundary line of the header refers to the visual separator between the header and the rest of the content.
+	HeaderBorder *OVStyle
+	// SectionHeaderBorder is the style that applies to the boundary line of the section header.
+	// The boundary line of the section header is the line that separates different sections in the header.
+	SectionHeaderBorder *OVStyle
+	// VerticalHeaderBorder is the style that applies to the boundary character of the vertical header.
+	// The boundary character of the vertical header refers to the visual separator that delineates the vertical header from the rest of the content.
+	VerticalHeaderBorder *OVStyle
+}
+
+// deprecatedStyleConfig is the old style setting.
+type deprecatedStyleConfig struct {
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.ColumnRainbow instead.
+	StyleColumnRainbow []OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.MultiColorHighlight instead.
+	StyleMultiColorHighlight []OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.Header instead.
+	StyleHeader OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.Body instead.
+	StyleBody OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.LineNumber instead.
+	StyleLineNumber OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.SearchHighlight instead.
+	StyleSearchHighlight OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.ColumnHighlight instead.
+	StyleColumnHighlight OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.MarkLine instead.
+	StyleMarkLine OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.SectionLine instead.
+	StyleSectionLine OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.VerticalHeader instead.
+	StyleVerticalHeader OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.JumpTargetLine instead.
+	StyleJumpTargetLine OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.Alternate instead.
+	StyleAlternate OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.Ruler instead.
+	StyleRuler OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.HeaderBorder instead.
+	StyleHeaderBorder OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.SectionHeaderBorder instead.
+	StyleSectionHeaderBorder OVStyle
+	// Deprecated: This setting is planned to be removed in future versions.
+	// Use General.Style.VerticalHeaderBorder instead.
+	StyleVerticalHeaderBorder OVStyle
 }

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -108,7 +108,7 @@ func (root *Root) drawHeader() {
 		lX, lN = root.drawLine(y, lX, lN, lineC)
 		root.drawVerticalHeader(y, wrapNum, lineC)
 		// header style.
-		root.applyStyleToLine(y, root.StyleHeader)
+		root.applyStyleToLine(y, m.Style.Header)
 
 		wrapNum++
 		if lX == 0 {
@@ -116,7 +116,7 @@ func (root *Root) drawHeader() {
 		}
 	}
 	if root.scr.headerEnd > 0 {
-		root.applyStyleToLine(m.headerHeight-1, root.StyleHeaderBorder)
+		root.applyStyleToLine(m.headerHeight-1, m.Style.HeaderBorder)
 	}
 }
 
@@ -138,7 +138,7 @@ func (root *Root) drawSectionHeader() {
 
 		nextLX, nextLN := root.drawLine(y, lX, lN, lineC)
 		// section header style.
-		root.applyStyleToLine(y, root.StyleSectionLine)
+		root.applyStyleToLine(y, m.Style.SectionLine)
 
 		root.drawVerticalHeader(y, wrapNum, lineC)
 		// markstyle is displayed above the section header.
@@ -157,7 +157,7 @@ func (root *Root) drawSectionHeader() {
 		lX = nextLX
 		lN = nextLN
 	}
-	root.applyStyleToLine(m.headerHeight+m.sectionHeaderHeight-1, root.StyleSectionHeaderBorder)
+	root.applyStyleToLine(m.headerHeight+m.sectionHeaderHeight-1, m.Style.SectionHeaderBorder)
 }
 
 // drawRuler draws the ruler.
@@ -172,7 +172,7 @@ func (root *Root) drawRuler() {
 		startX = root.scr.startX - root.Doc.x
 	}
 
-	style := applyStyle(defaultStyle, root.StyleRuler)
+	style := applyStyle(defaultStyle, root.Doc.Style.Ruler)
 	for x := 0; x < root.scr.vWidth; x++ {
 		n := x - startX + 1
 		if n < 0 {
@@ -271,13 +271,13 @@ func (root *Root) drawVerticalHeader(y int, wrapNum int, lineC LineC) {
 		if n < len(lineC.lc) {
 			c = lineC.lc[n]
 		}
-		style := applyStyle(c.style, root.StyleVerticalHeader)
+		style := applyStyle(c.style, root.Doc.Style.VerticalHeader)
 		if n == widthVH-2 && c.width == 2 {
-			style = applyStyle(defaultStyle, root.StyleVerticalHeaderBorder)
+			style = applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
 			screen.SetContent(root.scr.startX+n, y, c.mainc, c.combc, style)
 			return
 		} else if n == widthVH-1 {
-			style = applyStyle(defaultStyle, root.StyleVerticalHeaderBorder)
+			style = applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
 			screen.SetContent(root.scr.startX+n, y, c.mainc, c.combc, style)
 			return
 		}
@@ -342,7 +342,7 @@ func (root *Root) drawLineNumber(lN int, y int, valid bool) {
 	// Line numbers start at 1 except for skip and header lines.
 	number = number - m.firstLine() + 1
 
-	style := applyStyle(defaultStyle, root.StyleLineNumber)
+	style := applyStyle(defaultStyle, m.Style.LineNumber)
 	numC := []rune(fmt.Sprintf("%*d", root.scr.startX-1, number))
 	for i := 0; i < len(numC); i++ {
 		root.Screen.SetContent(i, y, numC[i], nil, style)
@@ -377,7 +377,7 @@ func (root *Root) coordinatesStyle(lN int, y int) {
 		root.applyStyleToAlternate(lN, y)
 	}
 	if root.Doc.jumpTargetHeight != 0 && root.Doc.headerHeight+root.Doc.jumpTargetHeight == y {
-		root.applyStyleToLine(y, root.StyleJumpTargetLine)
+		root.applyStyleToLine(y, root.Doc.Style.JumpTargetLine)
 	}
 }
 
@@ -386,7 +386,7 @@ func (root *Root) applyStyleToAlternate(lN int, y int) {
 	if (lN)%2 == 0 {
 		return
 	}
-	root.applyStyleToLine(y, root.StyleAlternate)
+	root.applyStyleToLine(y, root.Doc.Style.Alternate)
 }
 
 // applyStyleToLine applies the style from the left edge to the right edge of the physical line.
@@ -401,7 +401,7 @@ func (root *Root) applyMarkStyle(lN int, y int, width int) {
 	if !contains(m.marked, lN) {
 		return
 	}
-	root.applyStyleToRange(y, root.StyleMarkLine, 0, width)
+	root.applyStyleToRange(y, m.Style.MarkLine, 0, width)
 }
 
 // applyStyleToRange applies the style from the start to the end of the physical line.
@@ -429,7 +429,7 @@ func (root *Root) sectionLineHighlight(y int, line LineC) {
 	if line.sectionNm <= 0 || line.sectionNm > root.Doc.SectionHeaderNum {
 		return
 	}
-	root.applyStyleToLine(y, root.StyleSectionLine)
+	root.applyStyleToLine(y, root.Doc.Style.SectionLine)
 }
 
 // hideOtherSection hides other sections.

--- a/oviewer/draw_test.go
+++ b/oviewer/draw_test.go
@@ -444,11 +444,11 @@ func TestRoot_sectionLineHighlight(t *testing.T) {
 				t.Errorf("Root.sectionLineHighlight() = %v, want %v", p, tt.wantStr)
 			}
 			if tt.wantStyle {
-				if style != applyStyle(tcell.StyleDefault, root.StyleSectionLine) {
-					t.Errorf("Root.sectionLineHighlight() = %v, want %v", style, root.StyleSectionLine)
+				if style != applyStyle(tcell.StyleDefault, root.Doc.Style.SectionLine) {
+					t.Errorf("Root.sectionLineHighlight() = %v, want %v", style, root.Doc.Style.SectionLine)
 				}
 			} else {
-				if style == applyStyle(tcell.StyleDefault, root.StyleSectionLine) {
+				if style == applyStyle(tcell.StyleDefault, root.Doc.Style.SectionLine) {
 					t.Errorf("Root.sectionLineHighlight() = %v, want %v", style, tcell.StyleDefault)
 				}
 			}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -600,10 +600,15 @@ func (root *Root) SetConfig(config Config) {
 	root.settings = setOldStyle(root.settings, config)
 	// General settings.
 	root.settings = updateRunTimeSettings(root.settings, config.General)
+
 	// view mode.
-	viewMode, overwrite := config.Mode[config.ViewMode]
-	if overwrite {
-		root.settings = updateRunTimeSettings(root.settings, viewMode)
+	if config.ViewMode != "" {
+		viewMode, overwrite := config.Mode[config.ViewMode]
+		if overwrite {
+			root.settings = updateRunTimeSettings(root.settings, viewMode)
+		} else {
+			root.setMessageLogf("view mode not found: %s", config.ViewMode)
+		}
 	}
 
 	// Set the follow mode for all documents.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -245,6 +245,48 @@ type RunTimeSettings struct {
 	SectionHeader bool
 	// HideOtherSection is whether to hide other sections.
 	HideOtherSection bool
+
+	// Style is the style of the document.
+	Style Style
+}
+
+// Style structure contains the style settings of the display.
+type Style struct {
+	// ColumnRainbow is the style that applies to the column rainbow color highlight.
+	ColumnRainbow []OVStyle
+	// MultiColorHighlight is the style that applies to the multi color highlight.
+	MultiColorHighlight []OVStyle
+	// Header is the style that applies to the header.
+	Header OVStyle
+	// Body is the style that applies to the body.
+	Body OVStyle
+	// LineNumber is a style that applies line number.
+	LineNumber OVStyle
+	// SearchHighlight is the style that applies to the search highlight.
+	SearchHighlight OVStyle
+	// ColumnHighlight is the style that applies to the column highlight.
+	ColumnHighlight OVStyle
+	// MarkLine is a style that marked line.
+	MarkLine OVStyle
+	// SectionLine is a style that section delimiter line.
+	SectionLine OVStyle
+	// VerticalHeader is a style that applies to the vertical header.
+	VerticalHeader OVStyle
+	// JumpTargetLine is the line that displays the search results.
+	JumpTargetLine OVStyle
+	// Alternate is a style that applies line by line.
+	Alternate OVStyle
+	// Ruler is a style that applies to the ruler.
+	Ruler OVStyle
+	// HeaderBorder is the style that applies to the boundary line of the header.
+	// The boundary line of the header refers to the visual separator between the header and the rest of the content.
+	HeaderBorder OVStyle
+	// SectionHeaderBorder is the style that applies to the boundary line of the section header.
+	// The boundary line of the section header is the line that separates different sections in the header.
+	SectionHeaderBorder OVStyle
+	// VerticalHeaderBorder is the style that applies to the boundary character of the vertical header.
+	// The boundary character of the vertical header refers to the visual separator that delineates the vertical header from the rest of the content.
+	VerticalHeaderBorder OVStyle
 }
 
 var (
@@ -402,6 +444,64 @@ func NewRunTimeSettings() RunTimeSettings {
 		TabWidth:       8,
 		MarkStyleWidth: 1,
 		Converter:      convEscaped,
+		Style:          NewStyle(),
+	}
+}
+
+// NewStyle returns the structure of Style with default values.
+func NewStyle() Style {
+	return Style{
+		Header: OVStyle{
+			Bold: true,
+		},
+		Alternate: OVStyle{
+			Background: "gray",
+		},
+		LineNumber: OVStyle{
+			Bold: true,
+		},
+		SearchHighlight: OVStyle{
+			Reverse: true,
+		},
+		ColumnHighlight: OVStyle{
+			Reverse: true,
+		},
+		MarkLine: OVStyle{
+			Background: "darkgoldenrod",
+		},
+		SectionLine: OVStyle{
+			Background: "slateblue",
+		},
+		VerticalHeader: OVStyle{},
+		VerticalHeaderBorder: OVStyle{
+			Background: "#c0c0c0",
+		},
+		MultiColorHighlight: []OVStyle{
+			{Foreground: "red"},
+			{Foreground: "aqua"},
+			{Foreground: "yellow"},
+			{Foreground: "fuchsia"},
+			{Foreground: "lime"},
+			{Foreground: "blue"},
+			{Foreground: "grey"},
+		},
+		ColumnRainbow: []OVStyle{
+			{Foreground: "white"},
+			{Foreground: "crimson"},
+			{Foreground: "aqua"},
+			{Foreground: "lightsalmon"},
+			{Foreground: "lime"},
+			{Foreground: "blue"},
+			{Foreground: "yellowgreen"},
+		},
+		JumpTargetLine: OVStyle{
+			Underline: true,
+		},
+		Ruler: OVStyle{
+			Background: "#333333",
+			Foreground: "#CCCCCC",
+			Bold:       true,
+		},
 	}
 }
 
@@ -496,6 +596,9 @@ func openFiles(fileNames []string) (*Root, error) {
 
 // SetConfig sets config.
 func (root *Root) SetConfig(config Config) {
+	// Old Style* settings are loaded with lower priority.
+	root.settings = setOldStyle(root.settings, config)
+	// General settings.
 	root.settings = updateRunTimeSettings(root.settings, config.General)
 	// view mode.
 	viewMode, overwrite := config.Mode[config.ViewMode]
@@ -795,6 +898,28 @@ func (root *Root) debugMessage(msg string) {
 	log.Printf("%s:%s", root.Doc.FileName, msg)
 }
 
+// setOldStyle applies deprecated style settings for backward compatibility.
+// Deprecated: This function is planned to be removed in future versions.
+// It reads and applies old style settings to maintain compatibility with older configurations.
+// Use the new style configuration methods instead.
+func setOldStyle(src RunTimeSettings, config Config) RunTimeSettings {
+	src.Style.Body = config.StyleBody
+	src.Style.Header = config.StyleHeader
+	src.Style.LineNumber = config.StyleLineNumber
+	src.Style.SearchHighlight = config.StyleSearchHighlight
+	src.Style.ColumnHighlight = config.StyleColumnHighlight
+	src.Style.MarkLine = config.StyleMarkLine
+	src.Style.SectionLine = config.StyleSectionLine
+	src.Style.VerticalHeader = config.StyleVerticalHeader
+	src.Style.JumpTargetLine = config.StyleJumpTargetLine
+	src.Style.Alternate = config.StyleAlternate
+	src.Style.Ruler = config.StyleRuler
+	src.Style.HeaderBorder = config.StyleHeaderBorder
+	src.Style.SectionHeaderBorder = config.StyleSectionHeaderBorder
+	src.Style.VerticalHeaderBorder = config.StyleVerticalHeaderBorder
+	return src
+}
+
 // updateRunTimeSettings updates the RunTimeSettings.
 func updateRunTimeSettings(src RunTimeSettings, dst General) RunTimeSettings {
 	if dst.TabWidth != nil {
@@ -896,7 +1021,60 @@ func updateRunTimeSettings(src RunTimeSettings, dst General) RunTimeSettings {
 	if dst.Raw != nil && *dst.Raw {
 		src.Converter = convRaw
 	}
+	src.Style = updateRuntimeStyle(src.Style, dst.Style)
+	return src
+}
 
+// updateRuntimeStyle updates the style.
+func updateRuntimeStyle(src Style, dst StyleConfig) Style {
+	if dst.ColumnRainbow != nil {
+		src.ColumnRainbow = *dst.ColumnRainbow
+	}
+	if dst.MultiColorHighlight != nil {
+		src.MultiColorHighlight = *dst.MultiColorHighlight
+	}
+	if dst.Header != nil {
+		src.Header = *dst.Header
+	}
+	if dst.Body != nil {
+		src.Body = *dst.Body
+	}
+	if dst.LineNumber != nil {
+		src.LineNumber = *dst.LineNumber
+	}
+	if dst.SearchHighlight != nil {
+		src.SearchHighlight = *dst.SearchHighlight
+	}
+	if dst.ColumnHighlight != nil {
+		src.ColumnHighlight = *dst.ColumnHighlight
+	}
+	if dst.MarkLine != nil {
+		src.MarkLine = *dst.MarkLine
+	}
+	if dst.SectionLine != nil {
+		src.SectionLine = *dst.SectionLine
+	}
+	if dst.VerticalHeader != nil {
+		src.VerticalHeader = *dst.VerticalHeader
+	}
+	if dst.JumpTargetLine != nil {
+		src.JumpTargetLine = *dst.JumpTargetLine
+	}
+	if dst.Alternate != nil {
+		src.Alternate = *dst.Alternate
+	}
+	if dst.Ruler != nil {
+		src.Ruler = *dst.Ruler
+	}
+	if dst.HeaderBorder != nil {
+		src.HeaderBorder = *dst.HeaderBorder
+	}
+	if dst.SectionHeaderBorder != nil {
+		src.SectionHeaderBorder = *dst.SectionHeaderBorder
+	}
+	if dst.VerticalHeaderBorder != nil {
+		src.VerticalHeaderBorder = *dst.VerticalHeaderBorder
+	}
 	return src
 }
 

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -402,7 +402,7 @@ func (root *Root) lineContent(lN int) LineC {
 	if m.ColumnMode {
 		lineC = m.columnRanges(lineC)
 	}
-	RangeStyle(lineC.lc, 0, len(lineC.lc), root.StyleBody)
+	RangeStyle(lineC.lc, 0, len(lineC.lc), m.Style.Body)
 	root.styleContent(lineC)
 	return lineC
 }
@@ -491,11 +491,11 @@ func (root *Root) columnHighlight(lineC LineC) {
 // multiColorHighlight applies styles to multiple words (regular expressions) individually.
 // The style of the first specified word takes precedence.
 func (root *Root) multiColorHighlight(lineC LineC) {
-	numC := len(root.StyleMultiColorHighlight)
+	numC := len(root.Doc.Style.MultiColorHighlight)
 	for i := len(root.Doc.multiColorRegexps) - 1; i >= 0; i-- {
 		indexes := searchPositionReg(lineC.str, root.Doc.multiColorRegexps[i])
 		for _, idx := range indexes {
-			RangeStyle(lineC.lc, lineC.pos.x(idx[0]), lineC.pos.x(idx[1]), root.StyleMultiColorHighlight[i%numC])
+			RangeStyle(lineC.lc, lineC.pos.x(idx[0]), lineC.pos.x(idx[1]), root.Doc.Style.MultiColorHighlight[i%numC])
 		}
 	}
 }
@@ -509,7 +509,7 @@ func (root *Root) searchHighlight(lineC LineC) {
 
 	indexes := root.searchPosition(lineC.str)
 	for _, idx := range indexes {
-		RangeStyle(lineC.lc, lineC.pos.x(idx[0]), lineC.pos.x(idx[1]), root.StyleSearchHighlight)
+		RangeStyle(lineC.lc, lineC.pos.x(idx[0]), lineC.pos.x(idx[1]), root.Doc.Style.SearchHighlight)
 	}
 }
 
@@ -573,14 +573,14 @@ func (m Document) columnWidthRanges(lineC LineC) []columnRange {
 // applyColumnStyles applies the styles to the columns based on the calculated ranges.
 func (root *Root) applyColumnStyles(lineC LineC) {
 	m := root.Doc
-	numC := len(root.StyleColumnRainbow)
+	numC := len(m.Style.ColumnRainbow)
 
 	for c, colRange := range lineC.columnRanges {
 		if m.ColumnRainbow {
-			RangeStyle(lineC.lc, colRange.start, colRange.end, root.StyleColumnRainbow[c%numC])
+			RangeStyle(lineC.lc, colRange.start, colRange.end, m.Style.ColumnRainbow[c%numC])
 		}
 		if c == m.columnCursor {
-			RangeStyle(lineC.lc, colRange.start, colRange.end, root.StyleColumnHighlight)
+			RangeStyle(lineC.lc, colRange.start, colRange.end, m.Style.ColumnHighlight)
 		}
 	}
 }

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -742,7 +742,7 @@ func TestRoot_columnDelimiterHighlight(t *testing.T) {
 			m.ColumnDelimiter = tt.fields.columnDelimiter
 			m.ColumnDelimiterReg = condRegexpCompile(m.ColumnDelimiter)
 			m.columnCursor = tt.fields.columnCursor
-			root.StyleColumnHighlight = OVStyle{Bold: true}
+			root.Doc.Style.ColumnHighlight = OVStyle{Bold: true}
 			lineC := root.Doc.getLineC(tt.args.lineNum)
 			lineC.columnRanges = root.Doc.columnDelimiterRange(lineC)
 			root.columnHighlight(lineC)
@@ -808,8 +808,8 @@ func TestRoot_columnWidthHighlight(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootFileReadHelper(t, filepath.Join(testdata, "ps.txt"))
-			root.StyleColumnHighlight = OVStyle{Bold: true}
 			m := root.Doc
+			m.Style.ColumnHighlight = OVStyle{Bold: true}
 			m.ColumnWidth = true
 			m.ColumnMode = true
 			root.prepareScreen()


### PR DESCRIPTION
Change Style config from Style* prefix to general/Style/.
This allows styles to be specified in Mode/Style as well.

The old Style* format is still supported but deprecated.

Updated `ov-less.yaml` and `ov.yaml` for improved style consistency.