### PR TITLE
Added clipboard via osc52

### DIFF
--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -55,9 +55,13 @@ type Config struct {
 	Incsearch bool
 	// NotifyEOF specifies the number of times to notify EOF.
 	NotifyEOF int
-	// UseOSC52Clipboard enables clipboard copy functionality using OSC52 escape sequence.
-	// Note: This may not work in all terminal emulators. Enable only if your terminal supports OSC52.
-	UseOSC52Clipboard bool
+
+	// ClipboardMethod specifies the method to use for copying to the clipboard.
+	// Supported values:
+	// - "OSC52": Uses the OSC52 escape sequence for clipboard operations. This requires terminal support.
+	// - "default": Uses the default clipboard method provided by the system or application.
+	// In fact, all other settings are default except for OSC52. In the future, “auto” will be added.
+	ClipboardMethod string
 
 	// ShrinkChar specifies the character to display when the column is shrunk.
 	ShrinkChar string

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	Incsearch bool
 	// NotifyEOF specifies the number of times to notify EOF.
 	NotifyEOF int
+	// UseOSC52Clipboard enables clipboard copy functionality using OSC52 escape sequence.
+	// Note: This may not work in all terminal emulators. Enable only if your terminal supports OSC52.
+	UseOSC52Clipboard bool
 
 	// ShrinkChar specifies the character to display when the column is shrunk.
 	ShrinkChar string

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -163,13 +163,18 @@ func (root *Root) copyToClipboard(_ context.Context) {
 	root.setMessage("Copy")
 }
 
+// copyClipboard copies the string to the clipboard.
+// The method of copying to the clipboard is determined by the configuration.
+// The default method is to use the clipboard package.
+// "OSC52” can be specified (available only if the terminal supports it).
 func (root *Root) copyClipboard(str string) {
-	if root.Config.UseOSC52Clipboard {
+	switch root.Config.ClipboardMethod {
+	case "OSC52":
 		root.Screen.SetClipboard([]byte(str))
-		return
-	}
-	if err := clipboard.WriteAll(str); err != nil {
-		log.Printf("copyToClipboard: %v\n", err)
+	default:
+		if err := clipboard.WriteAll(str); err != nil {
+			log.Printf("copyToClipboard: %v\n", err)
+		}
 	}
 }
 

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -155,14 +155,22 @@ func (root *Root) copyToClipboard(_ context.Context) {
 		root.debugMessage("copyToClipboard: " + err.Error())
 		return
 	}
-
 	if len(str) == 0 {
+		return
+	}
+
+	root.copyClipboard(str)
+	root.setMessage("Copy")
+}
+
+func (root *Root) copyClipboard(str string) {
+	if root.Config.UseOSC52Clipboard {
+		root.Screen.SetClipboard([]byte(str))
 		return
 	}
 	if err := clipboard.WriteAll(str); err != nil {
 		log.Printf("copyToClipboard: %v\n", err)
 	}
-	root.setMessage("Copy")
 }
 
 type eventPaste struct {


### PR DESCRIPTION
Implemented clipboard functionality using OSC52 escape sequences.
This needs to be set to enable copying with OSC52.
This implements #747 .