### PR TITLE
fix: Wait for EOF or ReadWaitTime before starting initial search

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -33,6 +33,8 @@ Prompt:
 
 # ShrinkChar: '…' # Characters displayed when the column is shrinking.
 
+# ReadWaitTime: 1s # Time to wait for a search while reading. 1s is the default.
+
 General:
   TabWidth: 4
   Header: 0

--- a/ov.yaml
+++ b/ov.yaml
@@ -32,6 +32,8 @@ Prompt:
 
 # ShrinkChar: '…' # Characters displayed when the column is shrinking.
 
+# ReadWaitTime: 1s # Time to wait for a search while reading. 1s is the default.
+
 General:
   TabWidth: 8
   Header: 0

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -56,6 +56,10 @@ type Config struct {
 	// NotifyEOF specifies the number of times to notify EOF.
 	NotifyEOF int
 
+	// ReadWaitTime is the time to wait for reading before starting a search.
+	// Measured in milliseconds.
+	ReadWaitTime int
+
 	// ClipboardMethod specifies the method to use for copying to the clipboard.
 	// Supported values:
 	// - "OSC52": Uses the OSC52 escape sequence for clipboard operations. This requires terminal support.
@@ -177,6 +181,7 @@ func NewConfig() Config {
 				ProcessOfCount: true,
 			},
 		},
+		ReadWaitTime: 1000,
 	}
 }
 

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -59,7 +59,6 @@ type Config struct {
 	NotifyEOF int
 
 	// ReadWaitTime is the time to wait for reading before starting a search.
-	// Measured in milliseconds.
 	ReadWaitTime time.Duration
 
 	// ClipboardMethod specifies the method to use for copying to the clipboard.

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -1,5 +1,7 @@
 package oviewer
 
+import "time"
+
 // Config represents the settings of ov.
 type Config struct {
 	// KeyBinding
@@ -58,7 +60,7 @@ type Config struct {
 
 	// ReadWaitTime is the time to wait for reading before starting a search.
 	// Measured in milliseconds.
-	ReadWaitTime int
+	ReadWaitTime time.Duration
 
 	// ClipboardMethod specifies the method to use for copying to the clipboard.
 	// Supported values:
@@ -181,7 +183,7 @@ func NewConfig() Config {
 				ProcessOfCount: true,
 			},
 		},
-		ReadWaitTime: 1000,
+		ReadWaitTime: 1000 * time.Millisecond,
 	}
 }
 

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -469,7 +469,7 @@ func (m *Document) WaitEOF() {
 	m.cond.Wait()
 }
 
-func (m *Document) WaitEOFWithTimeout(timeout int) {
+func (m *Document) WaitEOFWithTimeout(timeout time.Duration) {
 	if m.BufEOF() {
 		return
 	}
@@ -482,10 +482,9 @@ func (m *Document) WaitEOFWithTimeout(timeout int) {
 		doneCh <- struct{}{}
 	}()
 
-	timeoutCh := time.After(time.Duration(timeout) * time.Millisecond)
 	select {
 	case <-doneCh:
-	case <-timeoutCh:
+	case <-time.After(timeout):
 		log.Println("WaitEOFWithTimeout timed out")
 	}
 }

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -469,6 +469,9 @@ func (m *Document) WaitEOF() {
 	m.cond.Wait()
 }
 
+// WaitEOFWithTimeout waits for EOF with a timeout.
+// Parameters:
+// - timeout: the duration to wait before timing out.
 func (m *Document) WaitEOFWithTimeout(timeout time.Duration) {
 	if m.BufEOF() {
 		return

--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -15,6 +15,13 @@ type filterDocument struct {
 
 // Filter fires the filter event.
 func (root *Root) Filter(str string, nonMatch bool) {
+	go func() {
+		root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
+		root.sendFilter(str, nonMatch)
+	}()
+}
+
+func (root *Root) sendFilter(str string, nonMatch bool) {
 	root.Doc.nonMatch = nonMatch
 	root.input.value = str
 	ev := &eventInputSearch{

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -1115,6 +1115,7 @@ func updateRuntimeStyle(src Style, dst StyleConfig) Style {
 
 // docSmall returns with bool whether the file to display fits on the screen.
 func (root *Root) docSmall() bool {
+	root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
 	root.prepareScreen()
 	m := root.Doc
 	if !m.BufEOF() {

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -688,7 +688,10 @@ func (root *Root) sendNextBackSearch(context.Context) {
 // Normally, the event is executed from Confirm.
 func (root *Root) Search(str string) {
 	root.Pattern = str
-	root.sendSearch(str)
+	go func() {
+		root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
+		root.sendSearch(str)
+	}()
 }
 
 // eventSearch represents search event.


### PR DESCRIPTION
Addressed an intermittent search failure when using `ov` with `man`. 
The initial search now waits for EOF or the configured `ReadWaitTime` before starting, ensuring proper handling of input streams. 

fixed #765