### PR TITLE
Remove WaitEOFWithTimeout call when checking file size

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -1115,7 +1115,6 @@ func updateRuntimeStyle(src Style, dst StyleConfig) Style {
 
 // docSmall returns with bool whether the file to display fits on the screen.
 func (root *Root) docSmall() bool {
-	root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
 	root.prepareScreen()
 	m := root.Doc
 	if !m.BufEOF() {


### PR DESCRIPTION
The WaitEOFWithTimeout call was causing a 1-second delay when opening large files, which was unnecessary for file size checking.