### PR TITLE
Refactor: Adjust struct embedding for Screen, Config, and RunTimeSettings

### DIFF
--- a/examples/search/main.go
+++ b/examples/search/main.go
@@ -24,7 +24,7 @@ func main() {
 			log.Fatal(err)
 		}
 	}()
-	ov.StyleSearchHighlight = oviewer.OVStyle{
+	ov.Config.StyleSearchHighlight = oviewer.OVStyle{
 		Foreground: "gold",
 		Reverse:    true,
 		Blink:      true,

--- a/main.go
+++ b/main.go
@@ -189,8 +189,8 @@ func RunOviewer(args []string) error {
 		ov.Filter(nonMatchFilter, true)
 	}
 
-	if ov.QuitSmall && (filter != "" || nonMatchFilter != "") {
-		ov.QuitSmallFilter = true
+	if ov.Config.QuitSmall && (filter != "" || nonMatchFilter != "") {
+		ov.Config.QuitSmallFilter = true
 	}
 	// Run oviewer.
 	if err := ov.Run(); err != nil {

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -459,14 +459,14 @@ func (root *Root) setViewMode(ctx context.Context, modeName string) {
 	}
 	m := root.Doc
 	m.RunTimeSettings = settings
-	m.conv = m.converterType(m.RunTimeSettings.Converter)
+	m.conv = m.converterType(m.Converter)
+	// Set caption.
+	if settings.Caption != "" {
+		m.Caption = settings.Caption
+	}
 	m.regexpCompile()
 	m.ClearCache()
 	root.ViewSync(ctx)
-	// Set caption.
-	if m.RunTimeSettings.Caption != "" {
-		m.Caption = m.RunTimeSettings.Caption
-	}
 	root.setMessageLogf("Set mode %s", modeName)
 }
 
@@ -488,10 +488,10 @@ func (root *Root) modeConfig(modeName string) (RunTimeSettings, error) {
 // setConverter sets the converter type.
 func (root *Root) setConverter(ctx context.Context, name string) {
 	m := root.Doc
-	if m.RunTimeSettings.Converter == name {
+	if m.Converter == name {
 		return
 	}
-	m.RunTimeSettings.Converter = name
+	m.Converter = name
 	m.conv = m.converterType(name)
 	m.ClearCache()
 	root.ViewSync(ctx)
@@ -574,10 +574,10 @@ func (root *Root) setWriteBA(ctx context.Context, input string) {
 		root.setMessage(ErrInvalidNumber.Error())
 		return
 	}
-	root.BeforeWriteOriginal = before
-	root.AfterWriteOriginal = after
-	root.debugMessage(fmt.Sprintf("Before:After:%d:%d", root.BeforeWriteOriginal, root.AfterWriteOriginal))
-	root.IsWriteOnExit = true
+	root.Config.BeforeWriteOriginal = before
+	root.Config.AfterWriteOriginal = after
+	root.debugMessage(fmt.Sprintf("Before:After:%d:%d", root.Config.BeforeWriteOriginal, root.Config.AfterWriteOriginal))
+	root.Config.IsWriteOnExit = true
 	root.Quit(ctx)
 }
 
@@ -845,16 +845,16 @@ func (root *Root) Cancel(context.Context) {
 
 // toggleWriteOriginal toggles the write flag.
 func (root *Root) toggleWriteOriginal(context.Context) {
-	root.IsWriteOriginal = !root.IsWriteOriginal
-	root.setMessagef("Set WriteOriginal %t", root.IsWriteOriginal)
+	root.Config.IsWriteOriginal = !root.Config.IsWriteOriginal
+	root.setMessagef("Set WriteOriginal %t", root.Config.IsWriteOriginal)
 }
 
 // WriteQuit sets the write flag and executes a quit event.
 func (root *Root) WriteQuit(ctx context.Context) {
-	root.IsWriteOnExit = true
-	if root.Doc.HideOtherSection && root.AfterWriteOriginal == 0 {
+	root.Config.IsWriteOnExit = true
+	if root.Doc.HideOtherSection && root.Config.AfterWriteOriginal == 0 {
 		// hide other section.
-		root.AfterWriteOriginal = root.bottomSectionLN(ctx)
+		root.Config.AfterWriteOriginal = root.bottomSectionLN(ctx)
 	}
 	root.OnExit = root.ScreenContent()
 
@@ -864,11 +864,11 @@ func (root *Root) WriteQuit(ctx context.Context) {
 // bottomSectionLN returns the number of lines to write.
 func (root *Root) bottomSectionLN(ctx context.Context) int {
 	if root.Doc.SectionDelimiter == "" {
-		return root.AfterWriteOriginal
+		return root.Config.AfterWriteOriginal
 	}
 	lN, err := root.Doc.nextSection(ctx, root.Doc.topLN+root.Doc.firstLine()-root.Doc.SectionStartPosition)
 	if err != nil {
-		return root.AfterWriteOriginal
+		return root.Config.AfterWriteOriginal
 	}
 	return lN - (root.Doc.topLN + root.Doc.firstLine() - root.Doc.SectionStartPosition)
 }

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -87,24 +87,24 @@ func TestRoot_toggle(t *testing.T) {
 func TestToggleRuler(t *testing.T) {
 	root := rootHelper(t)
 	ctx := context.Background()
-	root.Doc.RunTimeSettings.RulerType = RulerNone
+	root.Doc.RulerType = RulerNone
 
 	// Test toggling from RulerNone to RulerRelative
 	root.toggleRuler(ctx)
-	if root.Doc.RunTimeSettings.RulerType != RulerRelative {
-		t.Errorf("expected RulerType to be RulerRelative, got %v", root.Doc.RunTimeSettings.RulerType)
+	if root.Doc.RulerType != RulerRelative {
+		t.Errorf("expected RulerType to be RulerRelative, got %v", root.Doc.RulerType)
 	}
 
 	// Test toggling from RulerRelative to RulerAbsolute
 	root.toggleRuler(ctx)
-	if root.Doc.RunTimeSettings.RulerType != RulerAbsolute {
-		t.Errorf("expected RulerType to be RulerAbsolute, got %v", root.Doc.RunTimeSettings.RulerType)
+	if root.Doc.RulerType != RulerAbsolute {
+		t.Errorf("expected RulerType to be RulerAbsolute, got %v", root.Doc.RulerType)
 	}
 
 	// Test toggling from RulerAbsolute to RulerNone
 	root.toggleRuler(ctx)
-	if root.Doc.RunTimeSettings.RulerType != RulerNone {
-		t.Errorf("expected RulerType to be RulerNone, got %v", root.Doc.RunTimeSettings.RulerType)
+	if root.Doc.RulerType != RulerNone {
+		t.Errorf("expected RulerType to be RulerNone, got %v", root.Doc.RulerType)
 	}
 }
 
@@ -1286,8 +1286,8 @@ func TestRoot_setWriteBA(t *testing.T) {
 			root := rootFileReadHelper(t, tt.fields.fileName)
 			ctx := context.Background()
 			root.setWriteBA(ctx, tt.args.input)
-			if root.IsWriteOnExit != tt.want {
-				t.Errorf("setWriteBA() = %v, want %v", root.IsWriteOnExit, tt.want)
+			if root.Config.IsWriteOnExit != tt.want {
+				t.Errorf("setWriteBA() = %v, want %v", root.Config.IsWriteOnExit, tt.want)
 			}
 		})
 	}
@@ -1511,7 +1511,7 @@ func TestRoot_WriteQuit(t *testing.T) {
 			root.prepareDraw(context.Background())
 			root.Doc.HideOtherSection = tt.fields.HideOtherSection
 			root.WriteQuit(ctx)
-			if got := root.AfterWriteOriginal; got != tt.want {
+			if got := root.Config.AfterWriteOriginal; got != tt.want {
 				t.Errorf("WriteQuit() AfterWriteOriginal = %v, want %v", got, tt.want)
 			}
 		})

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -261,7 +261,7 @@ func NewDocument() (*Document, error) {
 		return nil, err
 	}
 	m.alignConv = newAlignConverter(m.ColumnWidth)
-	m.conv = m.converterType(m.RunTimeSettings.Converter)
+	m.conv = m.converterType(m.Converter)
 
 	m.cond = sync.NewCond(&sync.Mutex{})
 	return m, nil

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -46,14 +46,14 @@ func (root *Root) draw(ctx context.Context) {
 	}
 
 	root.drawStatus()
-	root.Show()
+	root.Screen.Show()
 }
 
 // drawBody draws body.
 func (root *Root) drawBody(lX int, lN int) (int, int) {
 	m := root.Doc
 
-	markStyleWidth := min(root.scr.vWidth, root.Doc.RunTimeSettings.MarkStyleWidth)
+	markStyleWidth := min(root.scr.vWidth, root.Doc.MarkStyleWidth)
 
 	wrapNum := m.numOfWrap(lX, lN)
 	for y := m.headerHeight; y < root.scr.vHeight-statusLine; y++ {
@@ -143,7 +143,7 @@ func (root *Root) drawSectionHeader() {
 
 		root.drawVerticalHeader(y, wrapNum, lineC)
 		// markstyle is displayed above the section header.
-		markStyleWidth := min(root.scr.vWidth, m.RunTimeSettings.MarkStyleWidth)
+		markStyleWidth := min(root.scr.vWidth, m.MarkStyleWidth)
 		root.applyMarkStyle(lN, y, markStyleWidth)
 		// Underline search lines when they overlap in section headers.
 		if lN == m.lastSearchLN {
@@ -408,7 +408,7 @@ func (root *Root) applyMarkStyle(lN int, y int, width int) {
 // applyStyleToRange applies the style from the start to the end of the physical line.
 func (root *Root) applyStyleToRange(y int, s OVStyle, start int, end int) {
 	for x := start; x < end; x++ {
-		mainc, combc, style, width := root.GetContent(x, y)
+		mainc, combc, style, width := root.Screen.GetContent(x, y)
 		newStyle := applyStyle(style, s)
 		if style != newStyle {
 			root.Screen.SetContent(x, y, mainc, combc, newStyle)

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -419,7 +419,7 @@ func TestRoot_writeOriginal(t *testing.T) {
 				root.Doc.SectionHeader = true
 			}
 			root.prepareScreen()
-			root.AfterWriteOriginal = tt.fields.AfterWriteOriginal
+			root.Config.AfterWriteOriginal = tt.fields.AfterWriteOriginal
 			output := &bytes.Buffer{}
 			root.writeOriginal(output)
 			if gotOutput := output.String(); gotOutput != tt.want.output {
@@ -875,12 +875,12 @@ func TestRoot_prepareRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootHelper(t)
-			root.QuitSmall = tt.fields.QuitSmall
-			root.QuitSmallFilter = tt.fields.QuitSmallFilter
+			root.Config.QuitSmall = tt.fields.QuitSmall
+			root.Config.QuitSmallFilter = tt.fields.QuitSmallFilter
 			if err := root.prepareRun(context.Background()); (err != nil) != tt.wantErr {
 				t.Errorf("Root.prepareRun() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if got := root.QuitSmall; got != tt.wantQuit {
+			if got := root.Config.QuitSmall; got != tt.wantQuit {
 				t.Errorf("Root.prepareRun() = %v, want %v", got, tt.wantQuit)
 			}
 		})
@@ -1412,8 +1412,8 @@ func TestRoot_outputOnExit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootFileReadHelper(t, tt.fields.fileName)
 			root.prepareScreen()
-			root.IsWriteOnExit = tt.fields.IsWriteOnExit
-			root.IsWriteOriginal = tt.fields.IsWriteOriginal
+			root.Config.IsWriteOnExit = tt.fields.IsWriteOnExit
+			root.Config.IsWriteOriginal = tt.fields.IsWriteOriginal
 			buf := &bytes.Buffer{}
 			root.outputOnExit(buf)
 			gotOutput := buf.String()

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -643,7 +643,7 @@ func TestRoot_searchHighlight(t *testing.T) {
 
 			lineC := root.Doc.getLineC(tt.args.lineNum)
 			root.searcher = tt.fields.searcher
-			root.StyleSearchHighlight = OVStyle{Reverse: true}
+			root.Config.StyleSearchHighlight = OVStyle{Reverse: true}
 			root.searchHighlight(lineC)
 			if lineC.str != tt.want.str {
 				t.Errorf("\nline: %v\nwant: %v\n", lineC.str, tt.want.str)


### PR DESCRIPTION
Stopped embedding Screen and Config in the struct. Updated Doc to handle RunTimeSettings without embedding, addressing the issue with "could remove embedded field 'RunTimeSettings' from selector".