### PR TITLE
Add note StyleOverLine and StyleOverStrike

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,10 +1254,17 @@ Mode:
         Background: "blue"
 ```
 
+> **Note**: `StyleOverStrike` and `StyleOverLine` must be set at the top level and cannot be specified in the `Mode` section.
+>
+>```config.yaml
+>StyleOverStrike:
+>  Bold: true
+>StyleOverLine:
+>  Underline: true
+>```
+
 * Header
 * HeaderBorder
-* OverStrike
-* OverLine
 * LineNumber
 * SearchHighlight
 * ColumnHighlight

--- a/README.md
+++ b/README.md
@@ -1254,7 +1254,8 @@ Mode:
         Background: "blue"
 ```
 
-> **Note**: `StyleOverStrike` and `StyleOverLine` must be set at the top level and cannot be specified in the `Mode` section.
+> [!NOTE]
+> `StyleOverStrike` and `StyleOverLine` must be set at the top level and cannot be specified in the `Mode` section.
 >
 >```config.yaml
 >StyleOverStrike:


### PR DESCRIPTION
Added a note that StyleOverStrike and StyleOverLine cannot be specified in view mode. 
Fixed #770.