### PR TITLE
Add support for `ESC(B` as a reset operation in other sequence handling

### DIFF
--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -115,7 +115,7 @@ func (es *escapeSequence) parseEscapeSequence(st *parseState) bool {
 		es.parseCSI(st, mainc)
 		return true
 	case otherSequence:
-		es.state = ansiEscape
+		es.parseOther(st, mainc)
 		return true
 	case systemSequence:
 		es.parseOSC(st, mainc)
@@ -480,4 +480,17 @@ func oscStyle(style tcell.Style, paramStr string) tcell.Style {
 		style = style.Url(url)
 	}
 	return style
+}
+
+// parseOther parses the other escape sequences.
+func (es *escapeSequence) parseOther(_ *parseState, mainc rune) {
+	switch mainc {
+	case 'B': // ESC(B
+		es.parameter.Reset()
+		es.state = ansiText
+		return
+	case 0x1b: // ESC.
+		es.state = ansiEscape
+		return
+	}
 }

--- a/oviewer/convert_es.go
+++ b/oviewer/convert_es.go
@@ -184,6 +184,7 @@ func parseSGR(paramStr string) OVStyle {
 		switch sgr.code {
 		case 0: // Reset.
 			s = OVStyle{}
+			s.Reset = true
 		case 1: // Bold On
 			s.Bold = true
 			s.UnBold = false
@@ -483,10 +484,11 @@ func oscStyle(style tcell.Style, paramStr string) tcell.Style {
 }
 
 // parseOther parses the other escape sequences.
-func (es *escapeSequence) parseOther(_ *parseState, mainc rune) {
+func (es *escapeSequence) parseOther(st *parseState, mainc rune) {
 	switch mainc {
 	case 'B': // ESC(B
 		es.parameter.Reset()
+		st.style = tcell.StyleDefault
 		es.state = ansiText
 		return
 	case 0x1b: // ESC.

--- a/oviewer/convert_es_test.go
+++ b/oviewer/convert_es_test.go
@@ -97,7 +97,20 @@ func Test_escapeSequence_convert(t *testing.T) {
 				},
 			},
 			want:      true,
-			wantState: ansiEscape,
+			wantState: otherSequence,
+		},
+		{
+			name: "test-OtherSequence3",
+			fields: fields{
+				state: otherSequence,
+			},
+			args: args{
+				st: &parseState{
+					mainc: 'B',
+				},
+			},
+			want:      true,
+			wantState: ansiText,
 		},
 		{
 			name: "test-ControlSequence",

--- a/oviewer/convert_es_test.go
+++ b/oviewer/convert_es_test.go
@@ -405,6 +405,7 @@ func Test_parseSGR(t *testing.T) {
 				params: "38;5;216;0;4",
 			},
 			want: OVStyle{
+				Reset:     true,
 				Underline: true,
 			},
 		},

--- a/oviewer/ovstyle.go
+++ b/oviewer/ovstyle.go
@@ -50,6 +50,8 @@ type OVStyle struct {
 	UnStrikeThrough bool
 	// if true, sub overline (not yet supported).
 	UnOverLine bool
+	// If true, reset all styles.
+	Reset bool
 }
 
 // ToTcellStyle convert from OVStyle to tcell style.
@@ -75,6 +77,9 @@ func ToTcellStyle(s OVStyle) tcell.Style {
 
 // applyStyle applies the OVStyle to the tcell style.
 func applyStyle(style tcell.Style, s OVStyle) tcell.Style {
+	if s.Reset {
+		style = tcell.StyleDefault
+	}
 	if s.Foreground != "" {
 		style = style.Foreground(tcell.GetColor(s.Foreground))
 	}


### PR DESCRIPTION
Add support for handling the `ESC(B` sequence as a reset operation. This ensures compatibility with additional escape sequences and improves robustness in sequence handling.

fix: #774