### PR TITLE
Enable passing stripped escape sequences to the editor

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -409,18 +409,15 @@ func (root *Root) subShell(shell string) error {
 	if shell == "" {
 		shell = getShell()
 	}
-
 	stdin := os.Stdin
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		// Use TTY as stdin when the current stdin is not a terminal.
-		tty, err := getTty()
+	if !term.IsTerminal(int(stdin.Fd())) {
+		tty, err := getTTY()
 		if err != nil {
-			return fmt.Errorf("failed to open tty: %w", err)
+			return fmt.Errorf("failed to get stdin: %w", err)
 		}
 		defer tty.Close()
 		stdin = tty
 	}
-
 	c := exec.Command(shell, "-l")
 	c.Stdin = stdin
 	c.Stdout = os.Stdout
@@ -430,20 +427,6 @@ func (root *Root) subShell(shell string) error {
 	}
 	fmt.Println("resume ov")
 	return nil
-}
-
-func getShell() string {
-	if runtime.GOOS == "windows" {
-		return "CMD.EXE"
-	}
-	return "/bin/sh"
-}
-
-func getTty() (*os.File, error) {
-	if runtime.GOOS == "windows" {
-		return os.Open("CONIN$")
-	}
-	return os.Open("/dev/tty")
 }
 
 // setViewMode switches to the preset display mode.

--- a/oviewer/edit.go
+++ b/oviewer/edit.go
@@ -78,7 +78,7 @@ func (root *Root) saveTempFile() (string, error) {
 	}
 	defer tempFile.Close()
 
-	if err := root.Doc.Export(tempFile, root.Doc.BufStartNum(), root.Doc.BufEndNum()); err != nil {
+	if err := root.tempExport(tempFile); err != nil {
 		log.Printf("Failed to export document to temporary file: %v", err)
 		return "", err
 	}
@@ -86,6 +86,15 @@ func (root *Root) saveTempFile() (string, error) {
 	os.Chmod(fileName, 0o400) // Read-only permission
 
 	return fileName, nil
+}
+
+// tempExport exports the current document to a temporary file.
+func (root *Root) tempExport(tempFile *os.File) error {
+	if root.Doc.PlainMode {
+		// If the document is in plain mode, export it as plain text.
+		return root.Doc.ExportPlain(tempFile, root.Doc.BufStartNum(), root.Doc.BufEndNum())
+	}
+	return root.Doc.Export(tempFile, root.Doc.BufStartNum(), root.Doc.BufEndNum())
 }
 
 // identifyEditor determines the editor to use based on environment variables and configuration.

--- a/oviewer/store.go
+++ b/oviewer/store.go
@@ -373,3 +373,19 @@ func (s *store) export(w io.Writer, chunk *chunk, start int, end int) error {
 	}
 	return nil
 }
+
+// exportPlain exports the plain text without ANSI escape sequences.
+func (s *store) exportPlain(w io.Writer, chunk *chunk, start int, end int) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	start = max(0, start)
+	end = min(len(chunk.lines), end)
+	for i := start; i < end; i++ {
+		plain := stripEscapeSequenceBytes(chunk.lines[i])
+		if _, err := w.Write(plain); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"os"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 )
@@ -115,4 +117,20 @@ func stripEscapeSequenceBytes(src []byte) []byte {
 	}
 	// Remove EscapeSequence.
 	return stripRegexpES.ReplaceAll(src, []byte(""))
+}
+
+// getShell returns the shell name based on the operating system.
+func getShell() string {
+	if runtime.GOOS == "windows" {
+		return "CMD.EXE"
+	}
+	return "/bin/sh"
+}
+
+// getTTY returns the TTY file based on the operating system.
+func getTTY() (*os.File, error) {
+	if runtime.GOOS == "windows" {
+		return os.Open("CONIN$")
+	}
+	return os.Open("/dev/tty")
 }


### PR DESCRIPTION
When executing edit in plain mode, escape sequences are stripped before passing to the editor.