### PR TITLE
Move prompt settings to general and add other settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,8 +937,6 @@ This can be useful when you only want to view small files or when you want to qu
 
 If you want to enable this option by default, set `QuitSmall` to `true` in the configuration file.
 
-**Note:** The original text will be displayed without any styling applied by `ov`.
-
 ```yaml
 QuitSmall: true
 ```
@@ -1390,7 +1388,7 @@ General:
   StatusLine: false
 ```
 
-If you set StatusLine to false, the status line will not be displayed at all times; it will only appear when necessary (such as during search input).
+If you set `StatusLine` to false, the status line will not be displayed except when necessary (such as during search input).
 
 You can also customize the appearance and behavior of the status line by modifying the Prompt section in the configuration file.
 
@@ -1414,7 +1412,7 @@ General:
 | ProcessOfCount| Update the progress while counting the number of lines | true |
 | CursorType | Cursor type (see below) | 0 |
 
-Currently, CursorType is specified as a number (not all devices support this).
+Currently, set CursorType as a number (not all devices support this).
 
 | CursorType | Description |
 |:-----------|:------------|
@@ -1446,7 +1444,7 @@ General:
       InvertColor: false  # Important: Set this to false to enable LeftStatus styles
 ```
 
-> **Note:**
+> [!NOTE]
 > If `InvertColor` is set to `true`, the file name and related areas will be displayed with inverted colors, and the `LeftStatus`/`RightStatus` styles will not be applied.
 > To enable your custom styles, set `InvertColor: false`.
 
@@ -1472,7 +1470,7 @@ See [ov.yaml](https://github.com/noborus/ov/blob/master/ov.yaml) for more inform
 
 You can also customize the `General` configuration in the `config.yaml` file.
 
-> **Note**
+> [!NOTE]
 > All `General` configuration items can also be set for each view mode under the `Mode` section.
 > For example, you can specify `MultiColorWords` only for markdown mode as follows:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ ov is a terminal pager.
   * 8.1. [Style customization](#style-customization)
     * 8.1.1. [UnderlineStyle](#underlinestyle)
   * 8.2. [Customizing the bottom status line](#customizing-the-bottom-status-line)
+    * 8.2.1. [Customizing LeftStatus and RightStatus styles](#customizing-leftstatus-and-rightstatus-styles)
   * 8.3. [Key binding customization](#key-binding-customization)
   * 8.4. [General configuration](#general-configuration)
 * 9. [VS](#vs)
@@ -1287,6 +1288,8 @@ Mode:
 * VerticalHeader
 * VerticalHeaderBorder
 * Ruler
+* LeftStatus
+* RightStatus
 
 From `v0.40.0`, it is recommended to use the `Style:` format for configuration. For example:
 
@@ -1420,6 +1423,30 @@ Currently, CursorType is specified as a number (not all devices support this).
 | 4 | steady underline |
 | 5 | blinking bar |
 | 6 | steady bar |
+
+####  8.2.1. <a name='customizing-leftstatus-and-rightstatus-styles'></a>Customizing LeftStatus and RightStatus styles
+
+You can customize the style of the left and right areas of the status line using `LeftStatus` and `RightStatus` under the `Style` section.
+
+```yaml
+General:
+  Style:
+    LeftStatus:
+      Foreground: "yellow"
+      Background: "blue"
+      Bold: true
+    RightStatus:
+      Foreground: "white"
+      Background: "gray"
+      Italic: true
+  Prompt:
+    Normal:
+      InvertColor: false  # Important: Set this to false to enable LeftStatus styles
+```
+
+> **Note:**
+> If `InvertColor` is set to `true`, the file name and related areas will be displayed with inverted colors, and the `LeftStatus`/`RightStatus` styles will not be applied.
+> To enable your custom styles, set `InvertColor: false`.
 
 ###  8.3. <a name='key-binding-customization'></a>Key binding customization
 

--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ UnderlineStyle is specified by a number from 0 to 5. This corresponds to the esc
 
 ###  8.2. <a name='customizing-the-bottom-status-line'></a>Customizing the bottom status line
 
+*Added in v0.42.0*
+
 You can customize the bottom status line.
 
 The status line is displayed at the bottom of the screen and shows information such as the current file name, cursor position, and other details.

--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,7 @@ MemoryLimit: 1000
 |       | --skip-lines int                           | skip the number of lines                                       |
 |       | --smart-case-sensitive                     | smart case-sensitive in search                                 |
 | -x,   | --tab-width int                            | tab stop width (default 8)                                     |
+|       | --status-line[=true|false]                 | status line (default true)                                     |
 | -v,   | --version                                  | display version information                                    |
 | -y,   | --vertical-header int                      | number of characters to display as a vertical header           |
 | -m,   | --view-mode string                         | apply predefined settings for a specific mode                  |
@@ -1191,6 +1192,7 @@ It can also be changed after startup.
 | [alt+F]                       | * align columns                                    |
 | [alt+R]                       | * raw output                                       |
 | [alt+shift+F9]                | * ruler toggle                                     |
+| [ctrl+F10]                    | * status line toggle                               |
 | **Change Display with Input** |                                                    |
 | [p], [P]                      | * view mode selection                              |
 | [d]                           | * column delimiter string                          |
@@ -1375,14 +1377,29 @@ UnderlineStyle is specified by a number from 0 to 5. This corresponds to the esc
 
 You can customize the bottom status line.
 
-[Example]
+The status line is displayed at the bottom of the screen and shows information such as the current file name, cursor position, and other details.
+You can enable or disable the status line with the `StatusLine` option in the configuration file.
 
 ```yaml
-Prompt
-  Normal:
-    ShowFilename: false
-    InvertColor: false
-    ProcessOfCount: false
+General:
+  StatusLine: false
+```
+
+If you set StatusLine to false, the status line will not be displayed at all times; it will only appear when necessary (such as during search input).
+
+You can also customize the appearance and behavior of the status line by modifying the Prompt section in the configuration file.
+
+```yaml
+General:
+  StatusLine: true
+  Prompt:
+    Normal:
+      ShowFilename: true
+      InvertColor: true
+      ProcessOfCount: true
+      CursorType: 0
+    Input:
+      CursorType: 1
 ```
 
 | item name | description | default |
@@ -1390,6 +1407,19 @@ Prompt
 | ShowFilename| Display file name | true |
 | InvertColor| Display file name inverted and changed color| true |
 | ProcessOfCount| Update the progress while counting the number of lines | true |
+| CursorType | Cursor type (see below) | 0 |
+
+Currently, CursorType is specified as a number (not all devices support this).
+
+| CursorType | Description |
+|:-----------|:------------|
+| 0 | default |
+| 1 | blinking block |
+| 2 | steady block |
+| 3 | blinking underline |
+| 4 | steady underline |
+| 5 | blinking bar |
+| 6 | steady bar |
 
 ###  8.3. <a name='key-binding-customization'></a>Key binding customization
 
@@ -1463,6 +1493,8 @@ Mode:
 | PlainMode           | Enable plain (no decoration) mode                         | `PlainMode: true`               |
 | SectionHeader       | Display section header                                    | `SectionHeader: true`           |
 | HideOtherSection    | Hide other sections                                       | `HideOtherSection: true`        |
+| StatueLine          | Display status line at the bottom                         | `StatusLine: true`              |
+| Prompt              | Customize the bottom prompt                               | see [Customizing the bottom status line](#customizing-the-bottom-status-line) |
 
 ##  9. <a name='vs'></a>VS
 

--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -44,6 +44,10 @@ General:
 #      ShowFilename: true # Show the filename.
 #      InvertColor: true # Invert the color of the prompt.
 #      ProcessOfCount: true # Show the process of count.
+#      CursorType: 0 # Cursor type for the normal prompt.
+    Input:
+#      CursorType: 1 # Cursor type for the input prompt.
+
   # Style
   # String of the color name: Foreground, Background, UnderlineColor
   # Boolean: Bold, Blink, Dim, Italic, Underline

--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -25,11 +25,6 @@
 #
 # Debug: false # Debug mode.
 #
-Prompt:
-  Normal:
-#    ShowFilename: true # Show the filename.
-#    InvertColor: true # Invert the color of the prompt.
-#    ProcessOfCount: true # Show the process of count.
 
 # ShrinkChar: '…' # Characters displayed when the column is shrinking.
 
@@ -44,6 +39,11 @@ General:
   WrapMode: true
   ColumnDelimiter: ","
   MarkStyleWidth: 1
+  Prompt:
+    Normal:
+#      ShowFilename: true # Show the filename.
+#      InvertColor: true # Invert the color of the prompt.
+#      ProcessOfCount: true # Show the process of count.
   # Style
   # String of the color name: Foreground, Background, UnderlineColor
   # Boolean: Bold, Blink, Dim, Italic, Underline

--- a/ov.yaml
+++ b/ov.yaml
@@ -24,11 +24,6 @@
 #
 # Debug: false # Debug mode.
 #
-Prompt:
-  Normal:
-#    ShowFilename: true # Show the filename.
-#    InvertColor: true # Invert the color of the prompt.
-#    ProcessOfCount: true # Show the process of count.
 
 # ShrinkChar: '…' # Characters displayed when the column is shrinking.
 
@@ -43,6 +38,12 @@ General:
   WrapMode: true
   ColumnDelimiter: ","
   MarkStyleWidth: 1
+  Prompt:
+    Normal:
+#      ShowFilename: true # Show the filename.
+#      InvertColor: true # Invert the color of the prompt.
+#      ProcessOfCount: true # Show the process of count.
+
 #  SectionDelimiter: "^#"
   # Style
   # String of the color name: Foreground, Background, UnderlineColor

--- a/ov.yaml
+++ b/ov.yaml
@@ -43,6 +43,9 @@ General:
 #      ShowFilename: true # Show the filename.
 #      InvertColor: true # Invert the color of the prompt.
 #      ProcessOfCount: true # Show the process of count.
+#      CursorType: 0 # Cursor type for the normal prompt.
+    Input:
+#      CursorType: 1 # Cursor type for the input prompt.
 
 #  SectionDelimiter: "^#"
   # Style

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -1,6 +1,8 @@
 package oviewer
 
-import "time"
+import (
+	"time"
+)
 
 // Config represents the settings of ov.
 type Config struct {
@@ -154,8 +156,34 @@ type General struct {
 	HideOtherSection *bool
 	// StatusLine indicates whether to hide the status line.
 	StatusLine *bool
+	// Prompt is the prompt configuration.
+	Prompt PromptConfig
 	// Style is the style setting.
 	Style StyleConfig
+}
+
+// PromptConfigNormal is the normal prompt setting.
+type PromptConfigNormal struct {
+	// ShowFilename controls whether to display filename.
+	ShowFilename *bool
+	// InvertColor controls whether the text is colored and inverted.
+	InvertColor *bool
+	// ProcessOfCount controls whether to display the progress of the count.
+	ProcessOfCount *bool
+	// CursorType controls the type of cursor to display.
+	CursorType *int
+}
+
+// PromptConfigInput is the input prompt setting.
+type PromptConfigInput struct {
+	CursorType *int
+}
+
+// PromptConfig is the prompt setting.
+type PromptConfig struct {
+	// Normal is the normal prompt setting.
+	Normal PromptConfigNormal
+	Input  PromptConfigInput
 }
 
 // OVPromptConfigNormal is the normal prompt setting.
@@ -166,12 +194,32 @@ type OVPromptConfigNormal struct {
 	InvertColor bool
 	// ProcessOfCount controls whether to display the progress of the count.
 	ProcessOfCount bool
+	// CursorType controls the type of cursor to display.
+	CursorType int
+}
+
+// OVPromptConfigInput is the input prompt setting.
+type OVPromptConfigInput struct {
+	CursorType int
 }
 
 // OVPromptConfig is the prompt setting.
 type OVPromptConfig struct {
 	// Normal is the normal prompt setting.
 	Normal OVPromptConfigNormal
+	Input  OVPromptConfigInput
+}
+
+// NewOVPromptConfig returns the structure of OVPromptConfig with default values.
+func NewOVPromptConfig() OVPromptConfig {
+	return OVPromptConfig{
+		Normal: OVPromptConfigNormal{
+			ShowFilename:   true,
+			InvertColor:    true,
+			ProcessOfCount: true,
+		},
+		Input: OVPromptConfigInput{},
+	}
 }
 
 // NewConfig return the structure of Config with default values.
@@ -179,14 +227,7 @@ func NewConfig() Config {
 	return Config{
 		MemoryLimit:     -1,
 		MemoryLimitFile: 100,
-		Prompt: OVPromptConfig{
-			Normal: OVPromptConfigNormal{
-				ShowFilename:   true,
-				InvertColor:    true,
-				ProcessOfCount: true,
-			},
-		},
-		ReadWaitTime: 1000 * time.Millisecond,
+		ReadWaitTime:    1000 * time.Millisecond,
 	}
 }
 
@@ -227,6 +268,10 @@ type StyleConfig struct {
 	// VerticalHeaderBorder is the style that applies to the boundary character of the vertical header.
 	// The boundary character of the vertical header refers to the visual separator that delineates the vertical header from the rest of the content.
 	VerticalHeaderBorder *OVStyle
+	// LeftStatus is the style that applies to the left side of the status line.
+	LeftStatus *OVStyle
+	// RightStatus is the style that applies to the right side of the status line.
+	RightStatus *OVStyle
 }
 
 // deprecatedStyleConfig is the old style setting.

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	DefaultKeyBind string
 
 	// Prompt is the prompt setting.
-	Prompt OVPromptConfig
+	Prompt PromptConfig
 	// MinStartX is the minimum value of the start position.
 	MinStartX int
 

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -251,7 +251,7 @@ func (root *Root) sendUpdateEndNum() {
 	if !root.hasDocChanged() {
 		return
 	}
-	if !root.Config.Prompt.Normal.ProcessOfCount && !root.Doc.BufEOF() {
+	if !root.Doc.Normal.ProcessOfCount && !root.Doc.BufEOF() {
 		return
 	}
 	ev := &eventUpdateEndNum{}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -249,6 +249,8 @@ type RunTimeSettings struct {
 	// StatusLine is whether to hide the status line.
 	StatusLine bool
 
+	// PromptConfig is the prompt configuration.
+	OVPromptConfig
 	// Style is the style of the document.
 	Style Style
 }
@@ -290,6 +292,10 @@ type Style struct {
 	// VerticalHeaderBorder is the style that applies to the boundary character of the vertical header.
 	// The boundary character of the vertical header refers to the visual separator that delineates the vertical header from the rest of the content.
 	VerticalHeaderBorder OVStyle
+	// LeftStatus is the style that applies to the left status line.
+	LeftStatus OVStyle
+	// RightStatus is the style that applies to the right status line.
+	RightStatus OVStyle
 }
 
 var (
@@ -447,6 +453,7 @@ func NewRunTimeSettings() RunTimeSettings {
 		TabWidth:       8,
 		MarkStyleWidth: 1,
 		Converter:      convEscaped,
+		OVPromptConfig: NewOVPromptConfig(),
 		Style:          NewStyle(),
 		StatusLine:     true,
 	}
@@ -1065,7 +1072,29 @@ func updateRunTimeSettings(src RunTimeSettings, dst General) RunTimeSettings {
 	if dst.Raw != nil && *dst.Raw {
 		src.Converter = convRaw
 	}
+	src.OVPromptConfig = updatePromptConfig(src.OVPromptConfig, dst.Prompt)
 	src.Style = updateRuntimeStyle(src.Style, dst.Style)
+	return src
+}
+
+// updatePromptConfig updates the prompt configuration.
+func updatePromptConfig(src OVPromptConfig, dst PromptConfig) OVPromptConfig {
+	if dst.Normal.InvertColor != nil {
+		src.Normal.InvertColor = *dst.Normal.InvertColor
+	}
+	log.Println("updatePromptConfig:", dst.Normal.ShowFilename)
+	if dst.Normal.ShowFilename != nil {
+		src.Normal.ShowFilename = *dst.Normal.ShowFilename
+	}
+	if dst.Normal.ProcessOfCount != nil {
+		src.Normal.ProcessOfCount = *dst.Normal.ProcessOfCount
+	}
+	if dst.Normal.CursorType != nil {
+		src.Normal.CursorType = *dst.Normal.CursorType
+	}
+	if dst.Input.CursorType != nil {
+		src.Normal.CursorType = *dst.Normal.CursorType
+	}
 	return src
 }
 
@@ -1118,6 +1147,12 @@ func updateRuntimeStyle(src Style, dst StyleConfig) Style {
 	}
 	if dst.VerticalHeaderBorder != nil {
 		src.VerticalHeaderBorder = *dst.VerticalHeaderBorder
+	}
+	if dst.LeftStatus != nil {
+		src.LeftStatus = *dst.LeftStatus
+	}
+	if dst.RightStatus != nil {
+		src.RightStatus = *dst.RightStatus
 	}
 	return src
 }

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -976,14 +976,14 @@ func setOldStyle(src RunTimeSettings, config Config) RunTimeSettings {
 func setOldPrompt(src RunTimeSettings, config Config) RunTimeSettings {
 	prompt := config.Prompt
 	// Old PromptConfig settings are loaded with lower priority.
-	if !prompt.Normal.ShowFilename {
-		src.OVPromptConfig.Normal.ShowFilename = prompt.Normal.ShowFilename
+	if prompt.Normal.ShowFilename != nil {
+		src.OVPromptConfig.Normal.ShowFilename = *prompt.Normal.ShowFilename
 	}
-	if !prompt.Normal.InvertColor {
-		src.OVPromptConfig.Normal.InvertColor = prompt.Normal.InvertColor
+	if prompt.Normal.InvertColor != nil {
+		src.OVPromptConfig.Normal.InvertColor = *prompt.Normal.InvertColor
 	}
-	if !prompt.Normal.ProcessOfCount {
-		src.OVPromptConfig.Normal.ProcessOfCount = prompt.Normal.ProcessOfCount
+	if prompt.Normal.ProcessOfCount != nil {
+		src.OVPromptConfig.Normal.ProcessOfCount = *prompt.Normal.ProcessOfCount
 	}
 	return src
 }

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -609,6 +609,8 @@ func openFiles(fileNames []string) (*Root, error) {
 func (root *Root) SetConfig(config Config) {
 	// Old Style* settings are loaded with lower priority.
 	root.settings = setOldStyle(root.settings, config)
+	// Old Prompt settings are loaded with lower priority.
+	root.settings = setOldPrompt(root.settings, config)
 	// General settings.
 	root.settings = updateRunTimeSettings(root.settings, config.General)
 
@@ -968,6 +970,24 @@ func setOldStyle(src RunTimeSettings, config Config) RunTimeSettings {
 	return src
 }
 
+// setOldPrompt applies deprecated prompt settings for backward compatibility.
+//
+// Deprecated: This function is planned to be removed in future versions.
+func setOldPrompt(src RunTimeSettings, config Config) RunTimeSettings {
+	prompt := config.Prompt
+	// Old PromptConfig settings are loaded with lower priority.
+	if !prompt.Normal.ShowFilename {
+		src.OVPromptConfig.Normal.ShowFilename = prompt.Normal.ShowFilename
+	}
+	if !prompt.Normal.InvertColor {
+		src.OVPromptConfig.Normal.InvertColor = prompt.Normal.InvertColor
+	}
+	if !prompt.Normal.ProcessOfCount {
+		src.OVPromptConfig.Normal.ProcessOfCount = prompt.Normal.ProcessOfCount
+	}
+	return src
+}
+
 // updateRunTimeSettings updates the RunTimeSettings.
 func updateRunTimeSettings(src RunTimeSettings, dst General) RunTimeSettings {
 	if dst.TabWidth != nil {
@@ -1082,7 +1102,6 @@ func updatePromptConfig(src OVPromptConfig, dst PromptConfig) OVPromptConfig {
 	if dst.Normal.InvertColor != nil {
 		src.Normal.InvertColor = *dst.Normal.InvertColor
 	}
-	log.Println("updatePromptConfig:", dst.Normal.ShowFilename)
 	if dst.Normal.ShowFilename != nil {
 		src.Normal.ShowFilename = *dst.Normal.ShowFilename
 	}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -1112,7 +1112,7 @@ func updatePromptConfig(src OVPromptConfig, dst PromptConfig) OVPromptConfig {
 		src.Normal.CursorType = *dst.Normal.CursorType
 	}
 	if dst.Input.CursorType != nil {
-		src.Normal.CursorType = *dst.Normal.CursorType
+		src.Input.CursorType = *dst.Input.CursorType
 	}
 	return src
 }

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -52,17 +52,20 @@ func (root *Root) normalLeftStatus() (contents, int) {
 	}
 
 	leftStatus.WriteString(root.statusDisplay())
-
 	if root.Doc.Caption != "" {
 		leftStatus.WriteString(root.Doc.Caption)
-	} else if root.Config.Prompt.Normal.ShowFilename {
+	} else if root.Doc.Normal.ShowFilename {
 		leftStatus.WriteString(root.Doc.FileName)
 	}
 	leftStatus.WriteString(":")
 	leftStatus.WriteString(root.message)
 	leftContents := StrToContents(leftStatus.String(), -1)
 
-	if root.Config.Prompt.Normal.InvertColor {
+	RangeStyle(leftContents, 0, len(leftContents), root.Doc.Style.LeftStatus)
+	cursorColor := tcell.GetColor(root.Doc.Style.LeftStatus.Foreground)
+	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Input.CursorType), cursorColor)
+
+	if root.Doc.Normal.InvertColor {
 		for i := range leftContents {
 			leftContents[i].style = leftContents[i].style.Foreground(tcell.ColorValid + color).Reverse(true)
 		}
@@ -97,6 +100,11 @@ func (root *Root) inputLeftStatus() (contents, int) {
 	input := root.input
 	prompt := root.inputPrompt()
 	leftContents := StrToContents(prompt+input.value, -1)
+
+	cursorColor := tcell.GetColor(root.Doc.Style.LeftStatus.Foreground)
+	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Input.CursorType), cursorColor)
+	RangeStyle(leftContents, 0, len(leftContents), root.Doc.Style.LeftStatus)
+
 	return leftContents, len(prompt) + input.cursorX
 }
 
@@ -123,5 +131,7 @@ func (root *Root) rightStatus() contents {
 	if atomic.LoadInt32(&root.Doc.tmpFollow) == 1 {
 		str = fmt.Sprintf("(?/%d%s)", root.Doc.storeEndNum(), next)
 	}
-	return StrToContents(str, -1)
+	contents := StrToContents(str, -1)
+	RangeStyle(contents, 0, len(contents), root.Doc.Style.RightStatus)
+	return contents
 }

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -63,7 +63,7 @@ func (root *Root) normalLeftStatus() (contents, int) {
 
 	RangeStyle(leftContents, 0, len(leftContents), root.Doc.Style.LeftStatus)
 	cursorColor := tcell.GetColor(root.Doc.Style.LeftStatus.Foreground)
-	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Input.CursorType), cursorColor)
+	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Normal.CursorType), cursorColor)
 
 	if root.Doc.Normal.InvertColor {
 		for i := range leftContents {


### PR DESCRIPTION
Move prompt settings to general and add cursortype settings.
Add a note to README.md that the StatusLine can now be hidden.
Add StatusLine style settings.
The old prompt settings are still valid.

This is the remaining implementation of #426.