### PR TITLE
Fix inconsistent output after WriteQuit from help followed by Quit

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -844,6 +844,12 @@ func (root *Root) toggleWriteOriginal(context.Context) {
 
 // WriteQuit sets the write flag and executes a quit event.
 func (root *Root) WriteQuit(ctx context.Context) {
+	if root.Doc.documentType != DocNormal {
+		log.Println("WriteQuit: not a normal document")
+		root.Quit(ctx)
+		return
+	}
+
 	root.Config.IsWriteOnExit = true
 	if root.Doc.HideOtherSection && root.Config.AfterWriteOriginal == 0 {
 		// hide other section.


### PR DESCRIPTION
Previously, returning from the help screen with WriteQuit and then quitting with Quit could result in different output than expected. This commit ensures consistent output behavior when exiting ov after using WriteQuit in help mode.