### PR TITLE
Allow separate style settings for help and log documents

### DIFF
--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -28,6 +28,10 @@ type Config struct {
 
 	// GeneralConfig is the general setting.
 	General General
+	// helpConfig is the help setting.
+	HelpDoc General
+	// LogConfig is the log setting.
+	LogDoc General
 	// BeforeWriteOriginal specifies the number of lines before the current position.
 	// 0 is the top of the current screen
 	BeforeWriteOriginal int

--- a/oviewer/help.go
+++ b/oviewer/help.go
@@ -31,6 +31,7 @@ func NewHelp(k KeyBind) (*Document, error) {
 	m.SectionHeader = true
 	m.setSectionDelimiter("\t")
 	m.SectionHeaderNum = 1
+	m.Style = NewHelpStyle()
 	atomic.StoreInt32(&m.closed, 1)
 	if err := m.ControlReader(helpStr, nil); err != nil {
 		return nil, err
@@ -65,4 +66,43 @@ func DuplicateKeyBind(k KeyBind) string {
 		fmt.Fprintf(w, "%s [%s] for %s\n", gchalk.Red("Duplicate key"), v.key, strings.Join(v.action, ", "))
 	}
 	return w.String()
+}
+
+// NewHelpStyle returns a Style for the help document.
+func NewHelpStyle() Style {
+	return Style{
+		Header: OVStyle{
+			Foreground: "gold",
+			Background: "darkblue",
+			Bold:       true,
+		},
+		SectionLine: OVStyle{
+			Background: "slateblue",
+			Bold:       true,
+		},
+		Alternate: OVStyle{
+			Background: "gray",
+		},
+		LineNumber: OVStyle{
+			Bold: true,
+		},
+		SearchHighlight: OVStyle{
+			Reverse: true,
+		},
+		MarkLine: OVStyle{
+			Background: "darkgoldenrod",
+		},
+		MultiColorHighlight: []OVStyle{
+			{Foreground: "red"},
+			{Foreground: "aqua"},
+			{Foreground: "yellow"},
+			{Foreground: "fuchsia"},
+			{Foreground: "lime"},
+			{Foreground: "blue"},
+			{Foreground: "grey"},
+		},
+		JumpTargetLine: OVStyle{
+			Underline: true,
+		},
+	}
 }

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -64,3 +64,27 @@ func (logDoc *LogDocument) chanWrite() {
 		s.mu.Unlock()
 	}
 }
+
+// NewLogStyle generates a style for log documents.
+func NewLogStyle() Style {
+	return Style{
+		SearchHighlight: OVStyle{
+			Reverse: true,
+		},
+		MarkLine: OVStyle{
+			Background: "darkgoldenrod",
+		},
+		MultiColorHighlight: []OVStyle{
+			{Foreground: "red"},
+			{Foreground: "aqua"},
+			{Foreground: "yellow"},
+			{Foreground: "fuchsia"},
+			{Foreground: "lime"},
+			{Foreground: "blue"},
+			{Foreground: "grey"},
+		},
+		JumpTargetLine: OVStyle{
+			Underline: true,
+		},
+	}
+}

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -860,8 +860,9 @@ func (root *Root) prepareAllDocuments() {
 		}
 		log.Printf("open [%d]%s%s\n", n, doc.FileName, w)
 	}
-	root.helpDoc.Style = root.settings.Style
-	root.logDoc.Style = root.settings.Style
+
+	root.helpDoc.RunTimeSettings = updateRunTimeSettings(root.helpDoc.RunTimeSettings, root.Config.HelpDoc)
+	root.logDoc.RunTimeSettings = updateRunTimeSettings(root.logDoc.RunTimeSettings, root.Config.LogDoc)
 }
 
 // Close closes the oviewer.


### PR DESCRIPTION
- Added HelpDoc and LogDoc sections to the configuration for independent style settings
- Help and log documents now use their own style settings instead of inheriting from the main document
- View mode is not used for help and log pages; only style can be

implemented #799