### PR TITLE
Fix the method for specifying documents

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -844,7 +844,7 @@ func (root *Root) toggleWriteOriginal(context.Context) {
 
 // WriteQuit sets the write flag and executes a quit event.
 func (root *Root) WriteQuit(ctx context.Context) {
-	if root.Doc.documentType != DocNormal {
+	if root.Doc.documentType == DocHelp || root.Doc.documentType == DocLog {
 		log.Println("WriteQuit: not a normal document")
 		root.Quit(ctx)
 		return


### PR DESCRIPTION
Fix the method for specifying documents that do not allow WriteQuit.
Add a filter document to allow WriteQuit.