### PR TITLE
Fix Getpgrp support for cross-platform compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/ulikunitz/xz v0.5.12
 	golang.org/x/sync v0.15.0
+	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0
 )
 
@@ -40,7 +41,6 @@ require (
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/oviewer/suspend_other.go
+++ b/oviewer/suspend_other.go
@@ -1,5 +1,4 @@
-//go:build windows
-// +build windows
+//go:build !unix
 
 package oviewer
 
@@ -7,7 +6,7 @@ import (
 	"os"
 )
 
-// Dummy function because there is no sigtstp in windows.
+// Dummy function because there is no SIGTSTP in non-Unix systems.
 func registerSIGTSTP() chan os.Signal {
 	sigSuspend := make(chan os.Signal, 1)
 	return sigSuspend

--- a/oviewer/suspend_unix.go
+++ b/oviewer/suspend_unix.go
@@ -20,5 +20,5 @@ func registerSIGTSTP() chan os.Signal {
 // suspendProcess sends SIGSTOP signal to the process group.
 func suspendProcess() error {
 	pid := unix.Getpgrp()
-	return syscall.Kill(-pid, syscall.SIGSTOP)
+	return unix.Kill(-pid, syscall.SIGSTOP)
 }

--- a/oviewer/suspend_unix.go
+++ b/oviewer/suspend_unix.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build unix
 
 package oviewer
 
@@ -7,6 +6,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // registerSIGTSTP registers SIGTSTP signal.
@@ -18,6 +19,6 @@ func registerSIGTSTP() chan os.Signal {
 
 // suspendProcess sends SIGSTOP signal to the process group.
 func suspendProcess() error {
-	pid := syscall.Getpgrp()
+	pid := unix.Getpgrp()
 	return syscall.Kill(-pid, syscall.SIGSTOP)
 }


### PR DESCRIPTION
- Rename suspend.go to suspend_unix.go for Unix-specific implementation
- Rename suspend_windows.go to suspend_other.go for other platforms
- Update go.mod dependencies

Fixes #805