### PR TITLE
fix: rename unWatchMode to unwatchMode

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -168,7 +168,7 @@ func (root *Root) reload(m *Document) {
 // toggleWatch toggles watch mode.
 func (root *Root) toggleWatch(context.Context) {
 	if root.Doc.WatchMode {
-		root.Doc.unWatchMode()
+		root.Doc.unwatchMode()
 	} else {
 		root.Doc.watchMode()
 	}
@@ -551,7 +551,7 @@ func (root *Root) setWatchInterval(input string) {
 
 	root.Doc.WatchInterval = interval
 	if root.Doc.WatchInterval == 0 {
-		root.Doc.unWatchMode()
+		root.Doc.unwatchMode()
 	} else {
 		root.Doc.watchMode()
 	}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -28,7 +28,7 @@ const (
 	DocFilter
 )
 
-// documentType is the type of document.
+// documentType represents the type of document (e.g., normal, help, log, filter).
 type documentType int
 
 // String returns the string representation of the document type.
@@ -599,7 +599,7 @@ func (m *Document) watchMode() {
 }
 
 // unwatchMode unwatch mode for the document.
-func (m *Document) unWatchMode() {
+func (m *Document) unwatchMode() {
 	m.WatchMode = false
 	m.FollowSection = false
 }
@@ -666,7 +666,7 @@ func (m *Document) vHeaderWidth(lineC LineC) int {
 
 // GetLine returns one line from buffer.
 //
-// Deprecated: Use [Document.LineString] instead.
+// Deprecated: Use [Document.LineStr] instead.
 func (m *Document) GetLine(n int) string {
 	s, err := m.Line(n)
 	if err != nil {
@@ -675,9 +675,10 @@ func (m *Document) GetLine(n int) string {
 	return string(s)
 }
 
-// LineString returns one line from buffer.
+// LineString returns one line from the buffer as a string.
 //
-// Deprecated: Use [Document.LineStr] instead.
+// Deprecated: This method is deprecated because it does not return an error and may silently ignore failures.
+// Please use [Document.LineStr] instead, which returns both the string and an error for better error handling.
 func (m *Document) LineString(n int) string {
 	str, _ := m.LineStr(n)
 	return str

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -214,7 +214,7 @@ func (root *Root) handlers() map[string]func(context.Context) {
 	}
 }
 
-// KeyBind is the mapping of action and key.
+// KeyBind represents a mapping from action names to their associated key sequences.
 type KeyBind map[string][]string
 
 // defaultKeyBinds are the default keybindings.
@@ -506,7 +506,9 @@ func setHandler(ctx context.Context, c *cbind.Configuration, name string, keys [
 		}
 		if key == tcell.KeyRune {
 			c.SetRune(mod, ch, wrapEventHandler(ctx, handler))
-			// Added "shift+N" instead of 'N' to get it on windows.
+			// On Windows, some shifted keys (like 'N' as "shift+n") may not be recognized as their uppercase rune,
+			// so we explicitly bind both the plain and shifted versions to ensure the keybinding works across platforms.
+			// This is especially necessary for ASCII characters between '!' (0x21) and '`' (0x60).
 			if 0x21 <= ch && ch <= 0x60 {
 				c.SetRune(mod|tcell.ModShift, ch, wrapEventHandler(ctx, handler))
 			}


### PR DESCRIPTION
Rename unWatchMode to unwatchMode for consistent camelCase naming. Enhance documentation for deprecated methods with detailed explanations.