### PR TITLE
Separate Solaris/Illumos suspend implementation

### DIFF
--- a/oviewer/suspend_solaris.go
+++ b/oviewer/suspend_solaris.go
@@ -1,4 +1,4 @@
-//go:build unix && !solaris && !illumos
+//go:build solaris || illumos
 
 package oviewer
 
@@ -19,6 +19,10 @@ func registerSIGTSTP() chan os.Signal {
 
 // suspendProcess sends SIGSTOP signal to the process group.
 func suspendProcess() error {
-	pid := unix.Getpgrp()
+	pid, err := unix.Getpgrp()
+	if err != nil {
+		return err
+	}
+
 	return unix.Kill(-pid, syscall.SIGSTOP)
 }


### PR DESCRIPTION
Created suspend_solaris.go with proper error handling for unix.Getpgrp(). 
Updated suspend_unix.go build constraint to exclude solaris and illumos.
Fixes #805