### PR TITLE
Update README to reflect Homebrew Core availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ sudo port install ov
 ###  2.4. <a name='homebrew(macos-or-linux)'></a>Homebrew(macOS or Linux)
 
 ```console
+brew install ov
+```
+
+Or from the original tap:
+
+```console
 brew install noborus/tap/ov
 ```
 


### PR DESCRIPTION
- Update Homebrew installation instructions to prioritize official formula
- Add note about alternative tap installation method
- Homebrew Core formula is now available as 'brew install ov'

Closes #450