### PR TITLE
Enable column selection on double-click

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -20,6 +20,7 @@ import (
 func (root *Root) toggleWrapMode(context.Context) {
 	m := root.Doc
 	m.WrapMode = !m.WrapMode
+	root.resetSelect()
 
 	// Move cursor to correct position
 	x, err := m.optimalX(root.scr, m.columnCursor)
@@ -141,6 +142,7 @@ func (root *Root) toggleRuler(ctx context.Context) {
 		root.Doc.RulerType = RulerNone
 	}
 	root.setMessagef("Set Ruler %s", root.Doc.RulerType.String())
+	root.resetSelect()
 	root.ViewSync(ctx)
 }
 

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -21,6 +21,14 @@ func remove[T comparable](list []T, s T) []T {
 	return list
 }
 
+// abs returns the absolute value of an integer.
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
 // toAddTop adds the string if it is not in list.
 func toAddTop(list []string, s string) []string {
 	if len(s) == 0 {


### PR DESCRIPTION
When column selection is available, double-click now selects the column instead of a word. Refactored double-click handling to support both word and column selection. Updated selection logic and related functions to handle column boundaries. Reset selection when mouse actions cause selection to shift. Refactoring mouse variables.