### PR TITLE
Monitor EOF with goroutine and check docSmall for auto-quit timing

### DIFF
--- a/oviewer/doclist.go
+++ b/oviewer/doclist.go
@@ -54,6 +54,8 @@ func (root *Root) insertDocument(ctx context.Context, num int, m *Document) {
 	root.DocList = append(root.DocList[:num+1], append([]*Document{m}, root.DocList[num+1:]...)...)
 	root.mu.Unlock()
 
+	go root.waitForEOF(m)
+
 	root.setDocumentNum(ctx, num+1)
 	root.setMessageLogf("insert %s%s", m.FileName, m.Caption)
 }

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -496,8 +496,25 @@ func (root *Root) applySelectionRange(y int, start int, end int, selectState Mou
 	}
 }
 
+func (root *Root) quitCheck() bool {
+	if !root.Config.QuitSmall {
+		return false
+	}
+	if !root.docSmall() {
+		return false
+	}
+	if root.DocumentLen() == 1 && !root.Config.QuitSmallFilter {
+		root.Config.IsWriteOnExit = true
+		return true
+	}
+	return false
+}
+
 // notifyEOFReached notifies that EOF has been reached.
 func (root *Root) notifyEOFReached(m *Document) {
+	if root.Config.NotifyEOF == 0 {
+		return
+	}
 	root.setMessagef("EOF reached %s", m.FileName)
 	root.notify(root.Config.NotifyEOF)
 }

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -67,6 +67,10 @@ func (root *Root) event(ctx context.Context, ev tcell.Event) bool {
 	case *eventSearchMove:
 		root.searchGo(ctx, ev.ln, ev.searcher)
 	case *eventReachEOF:
+		// Quit if small doc and config allows
+		if root.quitCheck() {
+			return true
+		}
 		root.notifyEOFReached(ev.m)
 
 	// Input confirmation action event.
@@ -386,10 +390,6 @@ func (root *Root) sendReachEOF(m *Document) {
 
 // monitorEOF monitors the EOF of the document.
 func (root *Root) monitorEOF() {
-	if root.Config.NotifyEOF == 0 {
-		return
-	}
-	log.Println("monitorEOF")
 	for _, m := range root.DocList {
 		go root.waitForEOF(m)
 	}
@@ -403,5 +403,4 @@ func (root *Root) waitForEOF(m *Document) {
 		m.cond.L.Unlock()
 	}
 	root.sendReachEOF(m)
-	log.Println("EOF reached", m.FileName)
 }

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -97,6 +97,12 @@ func (root *Root) nextSection(ctx context.Context) {
 			root.setMessage("No more next sections")
 		}
 	}
+
+	if root.Config.QuitSmall {
+		// Reset quitSmallCountDown to avoid quitting when a key is pressed.
+		root.Config.QuitSmall = false
+		root.setMessage("Quit small mode canceled")
+	}
 }
 
 // prevSection moves up to the delimiter of the previous section.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -774,12 +774,6 @@ func (root *Root) Run() error {
 		return err
 	}
 
-	// Quit if fits on screen.
-	if root.Config.QuitSmall && root.DocumentLen() == 1 && root.docSmall() {
-		root.Config.IsWriteOnExit = true
-		return nil
-	}
-
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
 	sigSuspend := registerSIGTSTP()
@@ -834,6 +828,11 @@ func (root *Root) prepareRun(ctx context.Context) error {
 
 	root.setViewModeConfig()
 	root.prepareAllDocuments()
+	// follow mode or follow all disables quit if the output fits on one screen.
+	if root.Doc.FollowMode || root.FollowAll {
+		root.Config.QuitSmall = false
+		root.Config.QuitSmallFilter = false
+	}
 	// Quit by filter result. This is evaluated lazily.
 	if root.Config.QuitSmallFilter {
 		root.quitSmallCountDown = QuitSmallCountDown


### PR DESCRIPTION
Always start a goroutine to monitor EOF, regardless of notify-eof option. On EOF, check if docSmall should trigger auto-quit. This enables correct auto-quit even when file reading is slow or delayed. Fixes issue #853.