### PR TITLE
feat: Add sticky follow mode with pause indicator (||) (#858)

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -17,6 +17,7 @@
 #
 # DisableMouse: false # Disable mouse support.
 # DisableColumnCycle: false # Disable cycling when moving columns.
+# DisableStickyFollow: false # Disable sticky follow mode.
 #
 # ViewMode: markdown # Default view mode.
 #

--- a/ov.yaml
+++ b/ov.yaml
@@ -16,6 +16,7 @@
 #
 # DisableMouse: false # Disable mouse support.
 # DisableColumnCycle: false # Disable cycling when moving columns.
+# DisableStickyFollow: false # Disable sticky follow mode.
 #
 # ViewMode: markdown # Default view mode.
 #

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	ShrinkChar string
 	// DisableColumnCycle indicates whether to disable column cycling.
 	DisableColumnCycle bool
+	// DisableStickYFollow indicates whether to disable sticky follow mode.
+	DisableStickyFollow bool
 	// Debug indicates whether to enable debug output.
 	Debug bool
 	// deprecatedStyleConfig is the old style setting.

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -175,6 +175,8 @@ type Document struct {
 	reopenable bool
 	// nonMatch indicates if non-matching lines are searched.
 	nonMatch bool
+	// pauseFollow indicates if follow mode is paused.
+	pauseFollow bool
 	// General is the General settings.
 	General General
 }

--- a/oviewer/move.go
+++ b/oviewer/move.go
@@ -12,6 +12,7 @@ const bottomMargin = 2
 
 // Go to the top line.
 func (root *Root) moveTop(context.Context) {
+	root.setPauseFollow()
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -24,10 +25,12 @@ func (root *Root) moveBottom(context.Context) {
 	defer root.releaseEventBuffer()
 
 	root.Doc.moveBottom()
+	root.Doc.pauseFollow = false
 }
 
 // Move up one screen.
 func (root *Root) movePgUp(context.Context) {
+	root.setPauseFollow()
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -39,11 +42,14 @@ func (root *Root) movePgDn(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	root.Doc.movePgDn()
+	if root.Doc.movePgDn() {
+		root.Doc.pauseFollow = false
+	}
 }
 
 // Moves up half a screen.
 func (root *Root) moveHfUp(context.Context) {
+	root.setPauseFollow()
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -55,11 +61,14 @@ func (root *Root) moveHfDn(context.Context) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	root.Doc.moveHfDn()
+	if root.Doc.moveHfDn() {
+		root.Doc.pauseFollow = false
+	}
 }
 
 // Move up one line.
 func (root *Root) moveUpOne(context.Context) {
+	root.setPauseFollow()
 	root.moveUp(1)
 }
 
@@ -70,6 +79,7 @@ func (root *Root) moveDownOne(context.Context) {
 
 // Move up by n amount.
 func (root *Root) moveUp(n int) {
+	root.setPauseFollow()
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
@@ -81,7 +91,9 @@ func (root *Root) moveDown(n int) {
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 
-	root.Doc.moveYDown(n)
+	if root.Doc.moveYDown(n) {
+		root.Doc.pauseFollow = false
+	}
 }
 
 // nextSection moves down to the next section's delimiter.
@@ -90,6 +102,7 @@ func (root *Root) nextSection(ctx context.Context) {
 	defer root.releaseEventBuffer()
 
 	if err := root.Doc.moveNextSection(ctx); err != nil {
+		root.Doc.pauseFollow = false
 		// Move by page if there is no section.
 		root.Doc.movePgDn()
 		// Last section or no section.
@@ -107,6 +120,7 @@ func (root *Root) nextSection(ctx context.Context) {
 
 // prevSection moves up to the delimiter of the previous section.
 func (root *Root) prevSection(ctx context.Context) {
+	root.setPauseFollow()
 	root.resetSelect()
 	defer root.releaseEventBuffer()
 

--- a/oviewer/move_updown.go
+++ b/oviewer/move_updown.go
@@ -68,44 +68,46 @@ func (m *Document) moveLineNth(lN int, nTh int) (int, int) {
 }
 
 // movePgUp moves up one screen.
-func (m *Document) movePgUp() {
-	m.moveLimitYUp(m.height)
+func (m *Document) movePgUp() bool {
+	return m.moveLimitYUp(m.height)
 }
 
 // movePgDn moves down one screen.
-func (m *Document) movePgDn() {
-	m.moveYDown(m.height)
+func (m *Document) movePgDn() bool {
+	return m.moveYDown(m.height)
 }
 
 // moveHfUp moves up half a screen.
-func (m *Document) moveHfUp() {
-	m.moveLimitYUp(m.height / 2)
+func (m *Document) moveHfUp() bool {
+	return m.moveLimitYUp(m.height / 2)
 }
 
 // moveHfDn moves down half a screen.
-func (m *Document) moveHfDn() {
-	m.moveYDown(m.height / 2)
+func (m *Document) moveHfDn() bool {
+	return m.moveYDown(m.height / 2)
 }
 
 // limitMoveDown limits the movement of the cursor when moving down.
-func (m *Document) limitMoveDown(lX int, lN int) {
+// Returns true if reached the bottom line.
+func (m *Document) limitMoveDown(lX int, lN int) bool {
 	if lN+m.height < m.BufEndNum()-m.SkipLines {
 		m.topLX = lX
 		m.topLN = lN
-		return
+		return false
 	}
 
 	tX, tN := m.bottomLineNum(m.BufEndNum(), m.height-lastLineMargin)
 	if lN < tN || (lN == tN && lX < tX) {
 		m.topLX = lX
 		m.topLN = lN
-		return
+		return false
 	}
 	// move to bottom
 	if m.topLN < tN || (m.topLN == tN && m.topLX < tX) {
 		m.topLX = tX
 		m.topLN = tN
 	}
+	return true
 }
 
 // numOfWrap returns the number of wrap from lX and lN.
@@ -170,16 +172,14 @@ func (m *Document) numUp(lX int, lN int, upY int) (int, int) {
 }
 
 // moveYDown moves down by the specified number of y.
-func (m *Document) moveYDown(moveY int) {
+func (m *Document) moveYDown(moveY int) bool {
 	if !m.WrapMode {
-		m.limitMoveDown(0, m.topLN+moveY)
-		return
+		return m.limitMoveDown(0, m.topLN+moveY)
 	}
 
 	// WrapMode
 	if m.topLN < 0 {
-		m.limitMoveDown(m.topLX, m.topLN+1)
-		return
+		return m.limitMoveDown(m.topLX, m.topLN+1)
 	}
 	lN := m.topLN + m.firstLine()
 	lX := m.topLX
@@ -200,16 +200,18 @@ func (m *Document) moveYDown(moveY int) {
 		}
 		n++
 	}
-	m.limitMoveDown(lX, lN-m.firstLine())
+	return m.limitMoveDown(lX, lN-m.firstLine())
 }
 
-// moveLimitYUp moves up by the specified number of y.
+// limitMoveUp moves up by the specified number of y.
 // The movement is limited to the top of the document.
-func (m *Document) moveLimitYUp(moveY int) {
+func (m *Document) moveLimitYUp(moveY int) bool {
 	m.moveYUp(moveY)
 	if m.topLN < m.BufStartNum() {
 		m.moveTop()
+		return true
 	}
+	return false
 }
 
 // moveYUp moves up by the specified number of y.

--- a/oviewer/move_updown.go
+++ b/oviewer/move_updown.go
@@ -203,7 +203,7 @@ func (m *Document) moveYDown(moveY int) bool {
 	return m.limitMoveDown(lX, lN-m.firstLine())
 }
 
-// limitMoveUp moves up by the specified number of y.
+// moveLimitYUp moves up by the specified number of y.
 // The movement is limited to the top of the document.
 func (m *Document) moveLimitYUp(moveY int) bool {
 	m.moveYUp(moveY)

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -76,6 +76,15 @@ func (root *Root) normalLeftStatus() (contents, int) {
 
 // statusDisplay returns the status mode of the document.
 func (root *Root) statusDisplay() string {
+	stMode := root.statusMode()
+	if !root.Doc.pauseFollow {
+		return stMode
+	}
+	return fmt.Sprintf("||%s", stMode)
+}
+
+// statusMode returns the status mode of the document.
+func (root *Root) statusMode() string {
 	if root.Doc.WatchMode {
 		// Watch mode doubles as FollowSection mode.
 		return "(Watch)"


### PR DESCRIPTION
- Implements sticky follow mode enabled by default (configurable via DisableStickyFollow)
- Follow mode is automatically paused (||) when the user scrolls or moves away from the bottom
- Follow mode automatically resumes when moving to the bottom (e.g., with End key or bottom action)
- Status line shows only the pause (||) indicator when follow is paused; no resume instructions are displayed
- Refactors move and search actions to support sticky follow logic

Closes #858