### PR TITLE
fix: Prevent search freeze when cancel events don't keep up

### DIFF
--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -462,7 +462,7 @@ func (root *Root) cancelWait(cancel context.CancelFunc) error {
 		switch ev := ev.(type) {
 		case *tcell.EventKey: // cancel key?
 			c.Capture(ev)
-		case *eventSearchQuit: // found
+		case *eventSearchQuit, *eventSearchMove: // found or moved
 			// Replay events that occurred during the search.
 			for _, queued := range eventQueue {
 				root.postEvent(queued)
@@ -474,6 +474,8 @@ func (root *Root) cancelWait(cancel context.CancelFunc) error {
 			eventQueue = append(eventQueue, ev)
 		default:
 			// ignore other events.
+			log.Println("cancelWait: ignore event", ev)
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
- Handle eventSearchMove in cancelWait to prevent event queue buildup
- Add logging for ignored events in cancelWait for debugging
- Ensure proper event replay after search completion or cancellation

This fixes cases where the search could freeze when cancel/search events were processed faster than the event handling could keep up.