### PR TITLE
Fix duplicate key binding detection with proper normalization

### DIFF
--- a/ov.yaml
+++ b/ov.yaml
@@ -246,7 +246,7 @@ KeyBind:
     previous_doc:
         - "["
     toggle_mouse:
-        - "ctrl+f3"
+        - "ctrl+F4"
         - "ctrl+alt+r"
     multi_color:
         - "."

--- a/oviewer/help.go
+++ b/oviewer/help.go
@@ -56,9 +56,15 @@ func KeyBindString(k KeyBind) string {
 // DuplicateKeyBind returns a string representing duplicate key bindings.
 func DuplicateKeyBind(k KeyBind) string {
 	w := &strings.Builder{}
-	dupkey := findDuplicateKeyBind(k)
+	dupkey, errors := findDuplicateKeyBind(k)
+	if len(errors) > 0 {
+		fmt.Fprintf(w, "\n\t%s\n", gchalk.Bold("Invalid key bindings:"))
+		for _, err := range errors {
+			fmt.Fprintf(w, "%s %s\n", gchalk.Red("Error:"), err)
+		}
+	}
 	if len(dupkey) == 0 {
-		return ""
+		return w.String()
 	}
 	fmt.Fprintf(w, "\n\tDuplicate key bindings:\n")
 	for _, v := range dupkey {

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -512,16 +512,23 @@ func setHandler(ctx context.Context, c *cbind.Configuration, name string, keys [
 			if 0x21 <= ch && ch <= 0x60 {
 				c.SetRune(mod|tcell.ModShift, ch, wrapEventHandler(ctx, handler))
 			}
-		} else {
-			// ctrl+h, Backspace and ctrl+Backspace can only be assigned one handler.
-			if key == tcell.KeyBackspace || key == tcell.KeyBackspace2 {
-				c.SetKey(tcell.ModNone, tcell.KeyBackspace, wrapEventHandler(ctx, handler))
-				c.SetKey(tcell.ModNone, tcell.KeyBackspace2, wrapEventHandler(ctx, handler))
-				c.SetKey(tcell.ModCtrl, tcell.KeyBackspace, wrapEventHandler(ctx, handler))
-				c.SetKey(tcell.ModCtrl, tcell.KeyBackspace2, wrapEventHandler(ctx, handler))
-				continue
-			}
-			c.SetKey(mod, key, wrapEventHandler(ctx, handler))
+			continue
+		}
+
+		c.SetKey(mod, key, wrapEventHandler(ctx, handler))
+
+		// Special case: if ctrl+j is bound, also bind Enter to the same action.
+		if key == tcell.KeyEnter && strings.ToLower(k) == "ctrl+j" {
+			// Also bind to actual Ctrl+J event
+			c.SetKey(tcell.ModCtrl, tcell.KeyCtrlJ, wrapEventHandler(ctx, handler))
+		}
+
+		// ctrl+h, Backspace and ctrl+Backspace can only be assigned one handler.
+		if key == tcell.KeyBackspace || key == tcell.KeyBackspace2 {
+			c.SetKey(tcell.ModNone, tcell.KeyBackspace, wrapEventHandler(ctx, handler))
+			c.SetKey(tcell.ModNone, tcell.KeyBackspace2, wrapEventHandler(ctx, handler))
+			c.SetKey(tcell.ModCtrl, tcell.KeyBackspace, wrapEventHandler(ctx, handler))
+			c.SetKey(tcell.ModCtrl, tcell.KeyBackspace2, wrapEventHandler(ctx, handler))
 		}
 	}
 	return nil
@@ -554,7 +561,19 @@ func normalizeKey(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return cbind.Encode(dm, dk, dc)
+
+	encoded, err := cbind.Encode(dm, dk, dc)
+	if err != nil {
+		return "", err
+	}
+
+	// If the original was ctrl+J and encode result is Enter, keep ctrl+j
+	lowerKey := strings.ToLower(key)
+	if encoded == "Enter" && lowerKey == "ctrl+j" {
+		return "ctrl+j", nil
+	}
+
+	return encoded, nil
 }
 
 // normalizeKeyWithPrefix normalizes a key and adds input_ prefix if the action is an input action.


### PR DESCRIPTION
- Add normalizeKey() and normalizeKeyWithPrefix() functions to handle key notation variations (e.g., "ctrl+c" vs "Ctrl+C")
- Update findDuplicateKeyBind() to return both duplicates and errors
- Improve error handling to collect all validation issues instead of stopping at first error
- Enhance DuplicateKeyBind() to display invalid key bindings with clear error messages
- Rename duplicate struct to keyActionMapping for clarity
- Fix ov.yaml: change toggle_mouse key from "ctrl+f3" to "ctrl+F4" to resolve duplicate binding issue

This ensures more robust key binding validation and helps users identify and fix configuration issues more effectively.