### PR TITLE
Add configurable mouse wheel scroll lines (fixes #871)

### DIFF
--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -31,10 +31,6 @@
 
 # ReadWaitTime: 1s # Time to wait for a search while reading. 1s is the default.
 
-# WheelScrollLines is the number of lines to scroll with the mouse wheel.
-# Adjust this value to match your terminal's scroll speed.
-# WheelScrollLines: 2
-
 General:
   TabWidth: 4
   Header: 0
@@ -44,6 +40,8 @@ General:
   WrapMode: true
   ColumnDelimiter: ","
   MarkStyleWidth: 1
+# HScrollWidth: 10%
+# VScrollLines: 2
   Prompt:
     Normal:
 #      ShowFilename: true # Show the filename.

--- a/ov.yaml
+++ b/ov.yaml
@@ -30,10 +30,6 @@
 
 # ReadWaitTime: 1s # Time to wait for a search while reading. 1s is the default.
 
-# WheelScrollNum is the number of lines to scroll with the mouse wheel.
-# Adjust this value to match your terminal's scroll speed.
-# WheelScrollLines: 2
-
 General:
   TabWidth: 8
   Header: 0
@@ -43,6 +39,8 @@ General:
   WrapMode: true
   ColumnDelimiter: ","
   MarkStyleWidth: 1
+# HScrollWidth: 10%
+# VScrollLines: 2
   Prompt:
     Normal:
 #      ShowFilename: true # Show the filename.

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -82,8 +82,6 @@ type Config struct {
 	DisableColumnCycle bool
 	// DisableStickYFollow indicates whether to disable sticky follow mode.
 	DisableStickyFollow bool
-	// WheelScrollLines specifies the number of lines to scroll with the mouse wheel.
-	WheelScrollLines int
 	// Debug indicates whether to enable debug output.
 	Debug bool
 	// deprecatedStyleConfig is the old style setting.

--- a/oviewer/general.go
+++ b/oviewer/general.go
@@ -42,6 +42,8 @@ type General struct {
 	HScrollWidth *string
 	// HScrollWidthNum is the horizontal scroll width as an integer (number of columns).
 	HScrollWidthNum *int
+	// VScrollLines is the number of lines to scroll with the mouse wheel.
+	VScrollLines *int
 	// RulerType is the ruler type (0: none, 1: relative, 2: absolute).
 	RulerType *RulerType
 	// AlternateRows alternately style rows.
@@ -188,6 +190,10 @@ func (g *General) SetHScrollWidth(width string) {
 // SetHScrollWidthNum sets the horizontal scroll width as an integer.
 func (g *General) SetHScrollWidthNum(num int) {
 	g.HScrollWidthNum = &num
+}
+
+func (g *General) SetVScrollLines(num int) {
+	g.VScrollLines = &num
 }
 
 // SetRulerType sets the ruler type.

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -29,9 +29,8 @@ const (
 )
 
 var (
-	WheelScrollNum = 2                      // WheelScrollNum is the number of lines to scroll with the mouse wheel.
-	ClickInterval  = 500 * time.Millisecond // Double/triple click detection time
-	ClickDistance  = 2                      // Maximum allowed movement distance (in screen coordinates/cells) for double/triple click detection
+	ClickInterval = 500 * time.Millisecond // Double/triple click detection time
+	ClickDistance = 2                      // Maximum allowed movement distance (in screen coordinates/cells) for double/triple click detection
 )
 
 // ClickState holds the state for click detection.
@@ -89,13 +88,14 @@ func (root *Root) mouseEvent(ctx context.Context, ev *tcell.EventMouse) {
 // wheelUp moves the mouse wheel up.
 func (root *Root) wheelUp(context.Context) {
 	root.setMessage("")
-	root.moveUp(WheelScrollNum)
+	root.moveUp(root.Doc.VScrollLines)
 }
 
 // wheelDown moves the mouse wheel down.
 func (root *Root) wheelDown(context.Context) {
 	root.setMessage("")
-	root.moveDown(WheelScrollNum)
+	log.Println("vScrollLines:", root.Doc.VScrollLines)
+	root.moveDown(root.Doc.VScrollLines)
 }
 
 // wheelRight moves the mouse wheel right.

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -229,6 +229,8 @@ type RunTimeSettings struct {
 	HScrollWidth string
 	// HScrollWidthNum is the horizontal scroll width.
 	HScrollWidthNum int
+	// VScrollLines is the number of lines to scroll with the mouse wheel.
+	VScrollLines int
 	// RulerType is the ruler type (0: none, 1: relative, 2: absolute).
 	RulerType RulerType
 	// AlternateRows alternately style rows.
@@ -480,6 +482,7 @@ func NewRunTimeSettings() RunTimeSettings {
 		OVPromptConfig: NewOVPromptConfig(),
 		Style:          NewStyle(),
 		StatusLine:     true,
+		VScrollLines:   2,
 	}
 }
 
@@ -823,9 +826,6 @@ func (root *Root) prepareRun(ctx context.Context) error {
 	if !root.Config.DisableMouse {
 		root.Screen.EnableMouse(MouseFlags)
 	}
-	if root.Config.WheelScrollLines > 0 {
-		WheelScrollNum = root.Config.WheelScrollLines
-	}
 
 	if root.Config.ShrinkChar != "" {
 		Shrink = []rune(root.Config.ShrinkChar)[0]
@@ -1059,6 +1059,9 @@ func updateRunTimeSettings(src RunTimeSettings, dst General) RunTimeSettings {
 	}
 	if dst.HScrollWidthNum != nil {
 		src.HScrollWidthNum = *dst.HScrollWidthNum
+	}
+	if dst.VScrollLines != nil {
+		src.VScrollLines = *dst.VScrollLines
 	}
 	if dst.RulerType != nil {
 		src.RulerType = *dst.RulerType


### PR DESCRIPTION
- Add WheelScrollLines config option to control mouse wheel scroll speed
- Update WheelScrollNum from config.WheelScrollLines if specified
- Add documentation and examples in ov.yaml and ov-less.yaml
- Maintain backward compatibility with default value of 2 lines

This allows users to customize mouse wheel scroll speed to match their terminal settings, addressing the inconsistency mentioned in issue #871.