### PR TITLE
Fix wide character display issues in Windows Terminal

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -223,6 +223,9 @@ func (root *Root) drawWrapLine(y int, lX int, lN int, lineC LineC) (int, int) {
 			break
 		}
 		screen.SetContent(x, y, c.mainc, c.combc, c.style)
+		if c.width == 2 {
+			n++
+		}
 	}
 	return lX, lN
 }
@@ -245,6 +248,9 @@ func (root *Root) drawNoWrapLine(y int, lX int, lN int, lineC LineC) (int, int) 
 		}
 		c := lineC.lc[lX+n]
 		screen.SetContent(x, y, c.mainc, c.combc, c.style)
+		if c.width == 2 {
+			n++
+		}
 	}
 	lN++
 	return lX, lN
@@ -267,22 +273,28 @@ func (root *Root) drawVerticalHeader(y int, wrapNum int, lineC LineC) {
 	}
 
 	screen := root.Screen
-	for n := range widthVH {
+	x := root.scr.startX
+	for n := 0; n < widthVH; n++ {
 		c := DefaultContent
 		if n < len(lineC.lc) {
 			c = lineC.lc[n]
 		}
-		style := applyStyle(c.style, root.Doc.Style.VerticalHeader)
 		if n == widthVH-2 && c.width == 2 {
-			style = applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
-			screen.SetContent(root.scr.startX+n, y, c.mainc, c.combc, style)
+			style := applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
+			screen.SetContent(x, y, c.mainc, c.combc, style)
 			return
 		} else if n == widthVH-1 {
-			style = applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
-			screen.SetContent(root.scr.startX+n, y, c.mainc, c.combc, style)
+			style := applyStyle(defaultStyle, root.Doc.Style.VerticalHeaderBorder)
+			screen.SetContent(x, y, c.mainc, c.combc, style)
 			return
 		}
-		screen.SetContent(root.scr.startX+n, y, c.mainc, c.combc, style)
+		style := applyStyle(c.style, root.Doc.Style.VerticalHeader)
+		screen.SetContent(x, y, c.mainc, c.combc, style)
+		x++
+		if c.width == 2 {
+			x++
+			n++
+		}
 	}
 }
 
@@ -354,10 +366,15 @@ func (root *Root) drawLineNumber(lN int, y int, valid bool) {
 // setContentString is a helper function that draws a string with setContent.
 func (root *Root) setContentString(vx int, vy int, lc contents) {
 	screen := root.Screen
-	for x, content := range lc {
-		screen.SetContent(vx+x, vy, content.mainc, content.combc, content.style)
+	x := vx
+	for _, content := range lc {
+		screen.SetContent(x, vy, content.mainc, content.combc, content.style)
+		x++
+		if content.width == 2 {
+			x++
+		}
 	}
-	screen.SetContent(vx+len(lc), vy, 0, nil, defaultStyle.Normal())
+	screen.SetContent(x, vy, 0, nil, defaultStyle.Normal())
 }
 
 // clearEOL clears from the specified position to the right end.

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -190,6 +190,7 @@ func (root *Root) handlePrimaryButtonClick(ctx context.Context, ev *tcell.EventM
 
 // startSelection initializes a new selection.
 func (root *Root) startSelection(x, y int, modifiers tcell.ModMask) {
+	x, y = root.adjustPositionForWideChar(x, y)
 	root.scr.x1, root.scr.y1 = x, y
 	root.scr.x2, root.scr.y2 = x, y
 
@@ -206,7 +207,8 @@ func (root *Root) startSelection(x, y int, modifiers tcell.ModMask) {
 func (root *Root) handleSelectActive(ctx context.Context, ev *tcell.EventMouse, button tcell.ButtonMask) bool {
 	switch button {
 	case tcell.ButtonPrimary:
-		root.scr.x2, root.scr.y2 = ev.Position()
+		x, y := ev.Position()
+		root.scr.x2, root.scr.y2 = root.adjustPositionForWideChar(x, y)
 		return true
 	case tcell.ButtonNone:
 		// Check if mouse has moved enough to be considered a selection
@@ -222,6 +224,18 @@ func (root *Root) handleSelectActive(ctx context.Context, ev *tcell.EventMouse, 
 	default:
 		return true
 	}
+}
+
+// adjustPositionForWideChar adjusts the position if a wide character is clicked.
+func (root *Root) adjustPositionForWideChar(x, y int) (int, int) {
+	p, _, _, _ := root.Screen.GetContent(x, y)
+	if p == ' ' && x > 0 {
+		_, _, _, w := root.Screen.GetContent(x-1, y) // Adjust for clicking the second half of a wide character
+		if w == 2 {
+			x--
+		}
+	}
+	return x, y
 }
 
 // resetClickState resets the click state.


### PR DESCRIPTION
- Fix display corruption of double-width characters (CJK characters) in Windows Terminal
- Improve wide character rendering and positioning calculations
- Fix mouse selection issues when clicking on the second half of wide characters
- Add position adjustment for wide character clicks using Screen.GetContent() for better efficiency
- Ensure proper handling of double-width characters (width=2) and their placeholders (width=0)

This resolves display issues with CJK characters in Windows Terminal and improves mouse interaction with wide characters.