### PR TITLE
Add terminal title

### DIFF
--- a/main.go
+++ b/main.go
@@ -562,6 +562,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("view-mode", "m", "", "apply predefined settings for a specific mode")
 	_ = viper.BindPFlag("ViewMode", rootCmd.PersistentFlags().Lookup("view-mode"))
 
+	rootCmd.PersistentFlags().BoolP("set-terminal-title", "", false, "set terminal title")
+	_ = viper.BindPFlag("SetTerminalTitle", rootCmd.PersistentFlags().Lookup("set-terminal-title"))
+
 	rootCmd.PersistentFlags().BoolP("debug", "", false, "debug mode")
 	_ = viper.BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug"))
 }

--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -24,6 +24,8 @@
 # For ClipboardMethod, specify “OSC52” to copy using OSC52 (if the terminal supports it).
 # ClipboardMethod: "default" # Clipboard method. Options: "OSC52" or other.
 #
+# SetTerminalTitle: false # Set terminal title to display filename.
+#
 # Debug: false # Debug mode.
 #
 

--- a/ov.yaml
+++ b/ov.yaml
@@ -23,6 +23,8 @@
 # For ClipboardMethod, specify “OSC52” to copy using OSC52 (if the terminal supports it).
 # ClipboardMethod: "default" # Clipboard method. Options: "OSC52" or other.
 #
+# SetTerminalTitle: false # Set terminal title to display filename.
+#
 # Debug: false # Debug mode.
 #
 

--- a/oviewer/config.go
+++ b/oviewer/config.go
@@ -82,6 +82,8 @@ type Config struct {
 	DisableColumnCycle bool
 	// DisableStickYFollow indicates whether to disable sticky follow mode.
 	DisableStickyFollow bool
+	// SetTerminalTitle indicates whether to set the terminal title to display filename.
+	SetTerminalTitle bool
 	// Debug indicates whether to enable debug output.
 	Debug bool
 	// deprecatedStyleConfig is the old style setting.

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -46,6 +46,7 @@ func (root *Root) draw(ctx context.Context) {
 	}
 
 	root.drawStatus()
+	root.drawTitle()
 	root.Screen.Show()
 }
 
@@ -361,6 +362,21 @@ func (root *Root) drawLineNumber(lN int, y int, valid bool) {
 		root.Screen.SetContent(i, y, numC[i], nil, style)
 	}
 	root.Screen.SetContent(len(numC), y, ' ', nil, defaultStyle)
+}
+
+// drawTitle sets the terminal title if TerminalTitle is enabled.
+func (root *Root) drawTitle() {
+	if root.Config.SetTerminalTitle {
+		root.Screen.SetTitle(root.displayTitle())
+	}
+}
+
+// displayTitle returns the caption string of the document.
+func (root *Root) displayTitle() string {
+	if root.Doc.Caption != "" {
+		return root.Doc.Caption
+	}
+	return root.Doc.FileName
 }
 
 // setContentString is a helper function that draws a string with setContent.

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -51,12 +51,8 @@ func (root *Root) normalLeftStatus() (contents, int) {
 		}
 	}
 
-	leftStatus.WriteString(root.statusDisplay())
-	if root.Doc.Caption != "" {
-		leftStatus.WriteString(root.Doc.Caption)
-	} else if root.Doc.Normal.ShowFilename {
-		leftStatus.WriteString(root.Doc.FileName)
-	}
+	leftStatus.WriteString(root.displayStatus())
+	leftStatus.WriteString(root.displayTitle())
 	leftStatus.WriteString(":")
 	leftStatus.WriteString(root.message)
 	leftContents := StrToContents(leftStatus.String(), -1)
@@ -74,8 +70,8 @@ func (root *Root) normalLeftStatus() (contents, int) {
 	return leftContents, len(leftContents)
 }
 
-// statusDisplay returns the status mode of the document.
-func (root *Root) statusDisplay() string {
+// displayStatus returns the status mode of the document.
+func (root *Root) displayStatus() string {
 	stMode := root.statusMode()
 	if !root.Doc.pauseFollow {
 		return stMode

--- a/oviewer/status_line_test.go
+++ b/oviewer/status_line_test.go
@@ -157,7 +157,7 @@ func TestRoot_statusDisplay(t *testing.T) {
 			root.Doc.FollowName = tt.fields.FollowName
 			root.Doc.FollowMode = tt.fields.FollowMode
 			root.Doc.pauseFollow = tt.fields.pauseFollow
-			if got := root.statusDisplay(); got != tt.want {
+			if got := root.displayStatus(); got != tt.want {
 				t.Errorf("Root.statusDisplay() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
- Add SetTerminalTitle boolean flag to Config
- Implement drawTitle() to set terminal title using Screen.SetTitle()
- Add displayTitle() method to return caption or filename
- Refactor statusDisplay() from status_line.go for better separation
- Update config templates with SetTerminalTitle documentation
- Add command line flag --set-terminal-title

This allows users to set the terminal title with the current filename or caption, making it easier to identify which file is being viewed when multiple terminal tabs are open.

Fixes #881