### PR TITLE
Fix screen corruption with ambiguous width characters and emojis

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -147,6 +147,8 @@ type SCR struct {
 	mousePressed bool
 	// mouseRectangle is a flag for rectangle selection.
 	mouseRectangle bool
+	// forceDisplaySync forces synchronous display.
+	forceDisplaySync bool
 }
 
 // LineNumber is Number of logical lines and number of wrapping lines on the screen.


### PR DESCRIPTION
Add comprehensive display sync handling to prevent screen corruption when rendering characters that have width mismatches between tcell and terminal display.

Changes:
- Add needsDisplaySync() to detect problematic character sequences
- Wrap all Screen.SetContent calls with setContent() helper
- Use Screen.Sync() instead of Show() when problematic chars detected
- Add runewidth.IsAmbiguousWidth() check for ambiguous characters
- Add comprehensive tests for display sync detection

Fixes display corruption with:
- Ambiguous width characters (box drawing, mathematical symbols, arrows)
- Latin characters with diacritics (à, á, é, etc.)
- Regional indicator symbols (flag emojis like 🇺🇸, 🇯🇵)
- ZWJ sequences (👨‍⚕️)
- Combining characters and variation selectors
- Skin tone modifiers

The sync is triggered for:
- Any combining characters (ZWJ sequences, variation selectors)
- Ambiguous width characters that may render differently
- Regional indicator symbols and emoji ranges
- Complex character sequences

This prevents characters from remaining on screen after switching views and fixes display corruption with box drawing characters in tables. The sync is applied on the next frame after detection to ensure proper rendering. Note that Screen.Sync() is slower than Show() but necessary to prevent display corruption with these character types.