### PR TITLE
Refactor draw functions and move event-related functions

### DIFF
--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -125,6 +125,30 @@ func (root *Root) event(ctx context.Context, ev tcell.Event) bool {
 	return false
 }
 
+// quitCheck checks if it should quit when the document is small.
+func (root *Root) quitCheck() bool {
+	if !root.Config.QuitSmall {
+		return false
+	}
+	if !root.docSmall() {
+		return false
+	}
+	if root.DocumentLen() == 1 && !root.Config.QuitSmallFilter {
+		root.Config.IsWriteOnExit = true
+		return true
+	}
+	return false
+}
+
+// notifyEOFReached notifies that EOF has been reached.
+func (root *Root) notifyEOFReached(m *Document) {
+	if root.Config.NotifyEOF == 0 {
+		return
+	}
+	root.setMessagef("EOF reached %s", m.FileName)
+	root.execNotify(root.Config.NotifyEOF)
+}
+
 // sendGoto fires an eventGoto event that moves to the specified line.
 func (root *Root) sendGoto(num int) {
 	ev := &eventGoto{}


### PR DESCRIPTION
Reorganize drawing functions for better structure and move event-related functions from draw.go to event.go.

Changes:
- Refactor draw() to use defer for Screen.Sync()/Show() calls
- Move drawBody() logic into the function and set bottomLN/bottomLX there
- Add early returns to drawHeader() and drawSectionHeader() when not needed
- Simplify drawSelect() by moving parameter logic inside the function
- Move event-related functions from draw.go to event.go:
  - quitCheck() -> event.go
  - notifyEOFReached() -> event.go
  - notify() -> execNotify() in draw.go (renamed for clarity)

This improves code organization by separating drawing logic from event handling logic, and makes the draw functions more self-contained. The defer pattern ensures Screen.Sync()/Show() is always called even if drawing functions exit early.