### PR TITLE
Fix race condition in tests

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -839,8 +839,8 @@ func (root *Root) prepareRun(ctx context.Context) error {
 
 	if root.Config.ShrinkChar != "" {
 		Shrink = []rune(root.Config.ShrinkChar)[0]
+		SetShrinkContent(Shrink)
 	}
-	SetShrinkContent(Shrink)
 
 	root.setCaption()
 


### PR DESCRIPTION
Move SetShrinkContent() call inside the ShrinkChar condition check to avoid unnecessary global variable updates during parallel test execution.

Also refactor TestRoot_closeFile to TestDocument_closeFile for better test isolation and to avoid race conditions with goroutines.

Fixes race detector warnings in test suite.