### PR TITLE
Align string width calculation with tcell's uniseg

### DIFF
--- a/oviewer/content_test.go
+++ b/oviewer/content_test.go
@@ -475,7 +475,8 @@ func Test_StrToContentsCombining(t *testing.T) {
 			name: "testEmojiFlagSequence",
 			args: args{line: string([]rune{'\U0001f1ef', '\U0001f1f5'}), tabWidth: 4},
 			want: contents{
-				{width: 1, style: tcell.StyleDefault, mainc: rune('🇯'), combc: []rune{'🇵'}},
+				{width: 2, style: tcell.StyleDefault, mainc: rune('🇯'), combc: []rune{'🇵'}},
+				{width: 0, style: tcell.StyleDefault, mainc: 0, combc: nil},
 			},
 		},
 		{
@@ -492,7 +493,7 @@ func Test_StrToContentsCombining(t *testing.T) {
 			t.Parallel()
 			got := StrToContents(tt.args.line, tt.args.tabWidth)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseString() got = %v, want %v", got, tt.want)
+				t.Errorf("parseString() got = \n%#v, want \n%#v", got, tt.want)
 			}
 		})
 	}

--- a/oviewer/convert_align.go
+++ b/oviewer/convert_align.go
@@ -3,7 +3,7 @@ package oviewer
 import (
 	"regexp"
 
-	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 )
 
 // align is a converter that aligns columns.
@@ -80,7 +80,7 @@ func (a *align) convert(st *parseState) bool {
 		return false
 	}
 	a.count += 1
-	if runewidth.RuneWidth(st.mainc) > 1 {
+	if uniseg.StringWidth(string(append([]rune{st.mainc}, st.combc...))) > 1 {
 		a.count += 1
 	}
 
@@ -148,7 +148,7 @@ func (a *align) convertWidth(src contents) contents {
 		if a.isShrink(columnNum) {
 			dst = appendShrink(dst)
 			dst = append(dst, SpaceContent)
-			a.maxWidths[columnNum] = runewidth.RuneWidth(Shrink)
+			a.maxWidths[columnNum] = uniseg.StringWidth(string(Shrink))
 			start = end
 			continue
 		}


### PR DESCRIPTION
Replace uses of github.com/mattn/go-runewidth with github.com/rivo/uniseg for measuring string/grapheme widths.