### PR TITLE
Updated tcell to v2.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/gdamore/tcell/v2 v2.12.1
+	github.com/gdamore/tcell/v2 v2.12.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jwalton/gchalk v1.3.0
 	github.com/klauspost/compress v1.18.1
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/noborus/guesswidth v0.4.0
-	github.com/noborus/tcellansi v0.2.0
+	github.com/noborus/tcellansi v0.3.0
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uh
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.12.1 h1:UcivYwRuPcZLjAok2SJ+3LzJUiJR0+3qnUte7Hz6Rbg=
 github.com/gdamore/tcell/v2 v2.12.1/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
+github.com/gdamore/tcell/v2 v2.12.2 h1:7hBtHPlPGNH6/ZLl22eLl7q0kfNsL+FGEggcWZuk6jk=
+github.com/gdamore/tcell/v2 v2.12.2/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -48,6 +50,8 @@ github.com/noborus/guesswidth v0.4.0 h1:+PPh+Z+GM4mKmVrhYR4lpjeyBuLMSVo2arM+VErd
 github.com/noborus/guesswidth v0.4.0/go.mod h1:ghA6uh9RcK+uSmaDDmBMj/tRZ3BSpspDP6DMF5Xk3bc=
 github.com/noborus/tcellansi v0.2.0 h1:GoSLIya57T7IiojDyNLps+9SjjCaCuLmvnGqHr3ldYU=
 github.com/noborus/tcellansi v0.2.0/go.mod h1:hZhcjTUr0iNe3XmyErkIMW3kBQmKZTngSARCWF+DxT0=
+github.com/noborus/tcellansi v0.3.0 h1:3y76pmVryfjcJcvUH/Uz4XzVnFwOS9p/tb8rFH2Yquc=
+github.com/noborus/tcellansi v0.3.0/go.mod h1:C+YKeGloFGYJLV3qTZouGb1uc/UNRSpW9Gmri1GT/PE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=


### PR DESCRIPTION
Updated tcell to v2.12.2 due to issue [tcell#858](https://github.com/gdamore/tcell/issues/858) in v2.12.1.