### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/oviewer/ovstyle.go
+++ b/oviewer/ovstyle.go
@@ -156,17 +156,15 @@ func applyStyle(style tcell.Style, s OVStyle) tcell.Style {
 // only support 0-5.
 // 0: None, 1: Single, 2: Double, 3: Curly, 4: Dotted, 5: Dashed
 func underLineStyle(ustyle string) tcell.UnderlineStyle {
-	n, err := strconv.Atoi(ustyle)
+	val, err := strconv.ParseUint(ustyle, 10, 8)
 	if err != nil {
 		return tcell.UnderlineStyleNone
 	}
-
-	us := tcell.UnderlineStyle(n)
+	us := tcell.UnderlineStyle(val)
 	if us < tcell.UnderlineStyleNone || us > tcell.UnderlineStyleDashed {
 		// Note: It is not appropriate to turn off the underline style for out-of-range values.
 		// It is out of specification.
 		return tcell.UnderlineStyleNone
 	}
-
 	return us
 }


### PR DESCRIPTION
Potential fix for [https://github.com/noborus/ov/security/code-scanning/5](https://github.com/noborus/ov/security/code-scanning/5)

To fix the problem, we should avoid parsing into an architecture-dependent `int` (as with `strconv.Atoi`) when we eventually cast to a smaller, fixed-size type (`uint8`). Instead, parse the value directly as an unsigned integer of the correct bit size using `strconv.ParseUint` with size 8 (or as an `int` with a manual bounds check for 0–5). This avoids data truncation on conversion, robustly filtering out-of-range inputs. Specifically, in `underLineStyle`, replace `strconv.Atoi(ustyle)` with `strconv.ParseUint(ustyle, 10, 8)`, and handle out-of-range/invalid values. No new imports are necessary; adjust only within the `underLineStyle` function (lines 158–172).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
