### PR TITLE
feat: pipe buffer output to new document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1689,6 +1689,16 @@ You can customize key bindings.
 
 See [ov.yaml](https://github.com/noborus/ov/blob/master/ov.yaml) for more information.
 
+Pipe the current buffer to an external command by binding `pipe_buffer` (terminal output) or
+`pipe_buffer_doc` (open output as a new document). Example:
+
+```yaml
+    pipe_buffer:
+        - "|"
+    pipe_buffer_doc:
+        - "!"
+```
+
 > [!NOTE]
 > Some keys may not work depending on the terminal.
 > See also [Ctrl key and corresponding key pairs (commonly treated as the same in terminals)](#ctrl-key-and-corresponding-key-pairs-(commonly-treated-as-the-same-in-terminals)).

--- a/ov-less.yaml
+++ b/ov-less.yaml
@@ -275,6 +275,8 @@ KeyBind:
         - "alt+j"
     save_buffer:
         - "s"
+    pipe_buffer:
+        - "|"
     convert_type:
         - "ctrl+alt+t"
     align_format:

--- a/ov.yaml
+++ b/ov.yaml
@@ -256,6 +256,10 @@ KeyBind:
         - "."
     jump_target:
         - "j"
+    # pipe_buffer:
+    #     - "|"
+    # pipe_buffer_doc:
+    #     - "!"
     plain_mode:
         - "ctrl+e"
     rainbow_mode:

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -26,6 +26,7 @@ const (
 	DocHelp
 	DocLog
 	DocFilter
+	DocPipe
 )
 
 // documentType represents the type of document (e.g., normal, help, log, filter).
@@ -42,6 +43,8 @@ func (d documentType) String() string {
 		return "log"
 	case DocFilter:
 		return "filter"
+	case DocPipe:
+		return "pipe"
 	}
 	return "unknown"
 }

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -91,6 +91,12 @@ func (root *Root) event(ctx context.Context, ev tcell.Event) bool {
 		root.setMultiColor(ev.value)
 	case *eventSaveBuffer:
 		root.saveBuffer(ev.value)
+	case *eventPipeBuffer:
+		if ev.toDoc {
+			root.pipeBufferDoc(ctx, ev.value)
+		} else {
+			root.pipeBuffer(ev.value)
+		}
 	case *eventInputSearch:
 		root.firstSearch(ctx, ev.searchType)
 	case *eventSkipLines:

--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -50,6 +50,8 @@ const (
 	JumpTarget
 	// SaveBuffer is for saving the buffer.
 	SaveBuffer
+	// PipeBuffer is for piping the buffer to a command.
+	PipeBuffer
 	// SectionNum is for setting the section number.
 	SectionNum
 	// ConvertType is for setting the convert type.
@@ -91,6 +93,7 @@ func NewInput() *Input {
 	i.Candidate[MultiColor] = multiColorCandidate()
 	i.Candidate[JumpTarget] = jumpTargetCandidate()
 	i.Candidate[SaveBuffer] = blankCandidate()
+	i.Candidate[PipeBuffer] = blankCandidate()
 	i.Candidate[ConvertType] = converterCandidate()
 
 	i.Event = &eventNormal{}

--- a/oviewer/input_pipebuffer.go
+++ b/oviewer/input_pipebuffer.go
@@ -1,0 +1,72 @@
+package oviewer
+
+import (
+	"context"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+const (
+	pipeBufferPrompt    = "(Pipe)command:"
+	pipeBufferDocPrompt = "(PipeDoc)command:"
+)
+
+// inputPipeBuffer is a wrapper to move to pipe buffer mode (terminal output).
+func (root *Root) inputPipeBuffer(_ context.Context) {
+	input := root.input
+	input.reset()
+	input.Event = newPipeBufferEvent(input.Candidate[PipeBuffer], pipeBufferPrompt, false)
+}
+
+// inputPipeBufferDoc is a wrapper to move to pipe buffer mode (new document output).
+func (root *Root) inputPipeBufferDoc(_ context.Context) {
+	input := root.input
+	input.reset()
+	input.Event = newPipeBufferEvent(input.Candidate[PipeBuffer], pipeBufferDocPrompt, true)
+}
+
+// eventPipeBuffer represents the input event for pipe buffer mode.
+type eventPipeBuffer struct {
+	tcell.EventTime
+	clist  *candidate
+	value  string
+	prompt string
+	toDoc  bool
+}
+
+// newPipeBufferEvent returns an eventPipeBuffer for pipe buffer mode.
+func newPipeBufferEvent(clist *candidate, prompt string, toDoc bool) *eventPipeBuffer {
+	return &eventPipeBuffer{
+		clist:  clist,
+		prompt: prompt,
+		toDoc:  toDoc,
+	}
+}
+
+// Mode returns InputMode.
+func (*eventPipeBuffer) Mode() InputMode {
+	return PipeBuffer
+}
+
+// Prompt returns the prompt string in the input field.
+func (e *eventPipeBuffer) Prompt() string {
+	return e.prompt
+}
+
+// Confirm returns the event when the input is confirmed.
+func (e *eventPipeBuffer) Confirm(str string) tcell.Event {
+	e.value = str
+	e.clist.toLast(str)
+	e.SetEventNow()
+	return e
+}
+
+// Up returns strings when the up key is pressed during input.
+func (e *eventPipeBuffer) Up(_ string) string {
+	return e.clist.up()
+}
+
+// Down returns strings when the down key is pressed during input.
+func (e *eventPipeBuffer) Down(_ string) string {
+	return e.clist.down()
+}

--- a/oviewer/input_test.go
+++ b/oviewer/input_test.go
@@ -342,6 +342,14 @@ func TestRoot_inputPrompt(t *testing.T) {
 	if root.inputPrompt() != "(Save)file:" {
 		t.Errorf("Root.inputMode() = %v, want %v", root.inputPrompt(), "(Save)file:")
 	}
+	root.inputPipeBuffer(ctx)
+	if root.inputPrompt() != "(Pipe)command:" {
+		t.Errorf("Root.inputMode() = %v, want %v", root.inputPrompt(), "(Pipe)command:")
+	}
+	root.inputPipeBufferDoc(ctx)
+	if root.inputPrompt() != "(PipeDoc)command:" {
+		t.Errorf("Root.inputMode() = %v, want %v", root.inputPrompt(), "(PipeDoc)command:")
+	}
 	root.inputViewMode(ctx)
 	if root.inputPrompt() != "Mode:" {
 		t.Errorf("Root.inputMode() = %v, want %v", root.inputPrompt(), "Mode:")

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -87,6 +87,8 @@ const (
 	actionJumpTarget     = "jump_target"
 	actionMultiColor     = "multi_color"
 	actionSaveBuffer     = "save_buffer"
+	actionPipeBuffer     = "pipe_buffer"
+	actionPipeBufferDoc  = "pipe_buffer_doc"
 	actionSearch         = "search"
 	actionBackSearch     = "backsearch"
 	actionFilter         = "filter"
@@ -188,6 +190,8 @@ func (root *Root) handlers() map[string]func(context.Context) {
 		actionJumpTarget:     root.inputJumpTarget,
 		actionMultiColor:     root.inputMultiColor,
 		actionSaveBuffer:     root.inputSaveBuffer,
+		actionPipeBuffer:     root.inputPipeBuffer,
+		actionPipeBufferDoc:  root.inputPipeBufferDoc,
 		actionSearch:         root.inputForwardSearch,
 		actionBackSearch:     root.inputBackSearch,
 		actionFilter:         root.inputSearchFilter,
@@ -293,6 +297,8 @@ func defaultKeyBinds() KeyBind {
 		actionJumpTarget:     {"j"},
 		actionMultiColor:     {"."},
 		actionSaveBuffer:     {"S"},
+		actionPipeBuffer:     []string{},
+		actionPipeBufferDoc:  []string{},
 		actionSearch:         {"/"},
 		actionBackSearch:     {"?"},
 		actionFilter:         {"&"},
@@ -337,6 +343,8 @@ func (k KeyBind) String() string {
 	k.writeKeyBind(&b, actionFollowAll, "follow all mode toggle")
 	k.writeKeyBind(&b, actionToggleMouse, "enable/disable mouse")
 	k.writeKeyBind(&b, actionSaveBuffer, "save buffer to file")
+	k.writeKeyBind(&b, actionPipeBuffer, "pipe buffer to command (terminal)")
+	k.writeKeyBind(&b, actionPipeBufferDoc, "pipe buffer to command (new document)")
 
 	writeHeader(&b, "Moving")
 	k.writeKeyBind(&b, actionMoveDown, "forward by one line")

--- a/oviewer/pipe.go
+++ b/oviewer/pipe.go
@@ -1,0 +1,175 @@
+package oviewer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// pipeBuffer pipes the buffer content to the specified command using the terminal.
+func (root *Root) pipeBuffer(input string) {
+	cmdStr := strings.TrimSpace(input)
+	if cmdStr == "" {
+		root.setMessage("pipe command is empty")
+		return
+	}
+
+	log.Printf("Pipe buffer to command: %s\n", cmdStr)
+	if err := root.Screen.Suspend(); err != nil {
+		root.setMessageLog(err.Error())
+		return
+	}
+	defer func() {
+		log.Println("Resume from pipe")
+		if err := root.Screen.Resume(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	if err := root.runPipeCommand(cmdStr); err != nil {
+		fmt.Fprintf(os.Stderr, "pipe command error: %s\n", err)
+	}
+
+	fmt.Println("press any key to continue...")
+	if err := waitForKey(); err != nil {
+		log.Printf("waitForKey error: %s\n", err)
+	}
+}
+
+// pipeBufferDoc pipes the buffer content to the specified command and opens the output as a new document.
+func (root *Root) pipeBufferDoc(ctx context.Context, input string) {
+	cmdStr := strings.TrimSpace(input)
+	if cmdStr == "" {
+		root.setMessage("pipe command is empty")
+		return
+	}
+
+	sourceDoc := root.Doc
+	cmd := pipeCommand(cmdStr)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		root.setMessageLogf("pipe command error: %s", err)
+		return
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		root.setMessageLogf("pipe command error: %s", err)
+		return
+	}
+	if root.logDoc != nil {
+		cmd.Stderr = root.logDoc
+	} else {
+		cmd.Stderr = io.Discard
+	}
+
+	if err := cmd.Start(); err != nil {
+		root.setMessageLogf("pipe command error: %s", err)
+		return
+	}
+
+	render, err := renderDoc(sourceDoc, stdout)
+	if err != nil {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		root.setMessageLogf("pipe command error: %s", err)
+		return
+	}
+
+	render.documentType = DocPipe
+	render.Caption = "pipe:" + cmdStr
+	render.RunTimeSettings = sourceDoc.RunTimeSettings
+	render.regexpCompile()
+	render.conv = render.converterType(render.Converter)
+	root.insertDocument(ctx, root.CurrentDoc, render)
+	root.setMessageLogf("pipe buffer: %s", cmdStr)
+
+	go func() {
+		if err := exportBuffer(sourceDoc, stdin); err != nil {
+			log.Printf("pipe buffer export error: %s\n", err)
+		}
+		if err := stdin.Close(); err != nil {
+			log.Printf("pipe buffer stdin close error: %s\n", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			log.Printf("pipe command error: %s\n", err)
+		}
+	}()
+}
+
+// runPipeCommand runs the command with buffer content as stdin.
+func (root *Root) runPipeCommand(cmdStr string) error {
+	cmd := pipeCommand(cmdStr)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdin pipe: %w", err)
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	if err := exportBuffer(root.Doc, stdin); err != nil {
+		_ = stdin.Close()
+		return fmt.Errorf("failed to export buffer: %w", err)
+	}
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("failed to close stdin: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("command failed: %w", err)
+	}
+
+	return nil
+}
+
+func pipeCommand(cmdStr string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/c", cmdStr)
+	}
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = getShell()
+	}
+	return exec.Command(shell, "-c", cmdStr)
+}
+
+func exportBuffer(doc *Document, w io.Writer) error {
+	start := doc.BufStartNum()
+	end := doc.BufEndNum()
+	if doc.PlainMode {
+		return doc.ExportPlain(w, start, end)
+	}
+	return doc.Export(w, start, end)
+}
+
+// waitForKey waits for the user to press any key.
+func waitForKey() error {
+	tty, err := getTTY()
+	if err != nil {
+		return err
+	}
+	defer tty.Close()
+
+	oldState, err := term.MakeRaw(int(tty.Fd()))
+	if err != nil {
+		return err
+	}
+	defer term.Restore(int(tty.Fd()), oldState)
+
+	buf := make([]byte, 1)
+	_, err = tty.Read(buf)
+	return err
+}


### PR DESCRIPTION
## Summary
- add pipe buffer actions for terminal output and for opening output as a new document
- avoid a default key binding; document how to bind pipe_buffer/pipe_buffer_doc
- add a DocPipe type to label pipe output documents

## Motivation
Follow-up to feedback on #944 about offering pipe output as a new document and avoiding a default | binding.

## Testing
- go test ./oviewer