### PR TITLE
Fix mouse selection offset when horizontally scrolled

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -50,13 +50,13 @@ func (root *Root) drawBody() {
 	m := root.Doc
 	lX := m.topLX
 	lN := m.topLN + root.scr.headerEnd
+	wrapNum := 0
 	if !m.WrapMode { // If WrapMode is off, topLX is always 0.
 		lX = 0
+		wrapNum = m.numOfWrap(lX, lN)
 	}
 
 	markStyleWidth := min(root.Doc.width, root.Doc.MarkStyleWidth)
-
-	wrapNum := m.numOfWrap(lX, lN)
 	for y := m.headerHeight; y < root.scr.vHeight-root.scr.statusLineHeight; y++ {
 		lineC, ok := root.scr.lines[lN]
 		if !ok {
@@ -80,9 +80,8 @@ func (root *Root) drawBody() {
 
 		root.applyMarkStyle(lN, y, markStyleWidth)
 
-		wrapNum++
-		if nextLX == 0 {
-			wrapNum = 0
+		if m.WrapMode && nextLX > 0 {
+			wrapNum++
 		}
 
 		lX = nextLX
@@ -115,9 +114,8 @@ func (root *Root) drawHeader() {
 		// header style.
 		root.applyStyleToLine(y, m.Style.Header)
 
-		wrapNum++
-		if lX == 0 {
-			wrapNum = 0
+		if m.WrapMode && lX > 0 {
+			wrapNum++
 		}
 	}
 	if root.scr.headerEnd > 0 {
@@ -156,9 +154,8 @@ func (root *Root) drawSectionHeader() {
 			root.applyStyleToLine(y, OVStyle{Underline: true})
 		}
 
-		wrapNum++
-		if nextLX == 0 {
-			wrapNum = 0
+		if m.WrapMode && nextLX > 0 {
+			wrapNum++
 		}
 
 		lX = nextLX

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -398,7 +398,7 @@ func (root *Root) findColumnBoundaries(x, y int, lineC LineC, ln LineNumber) (in
 
 // findWordBoundariesInLine selects the word at the given position.
 func (root *Root) findWordBoundariesInLine(x, y int, lineC LineC, ln LineNumber) (int, int, int, int) {
-	x = x - root.Doc.bodyStartX
+	x = root.Doc.scrollX + (x - root.Doc.bodyStartX)
 	contentX := x + branchWidth(lineC.lc, ln.wrap, root.scr.vWidth, root.Doc.bodyStartX)
 	if contentX < 0 || contentX >= len(lineC.lc) {
 		// Out of bounds: return clicked position only
@@ -433,7 +433,8 @@ func (root *Root) findWordBoundariesInLine(x, y int, lineC LineC, ln LineNumber)
 			ln.wrap++
 		}
 	}
-	return startX + root.Doc.bodyStartX, startY, endX + root.Doc.bodyStartX, endY
+	return (startX + root.Doc.bodyStartX) - root.Doc.scrollX, startY, (endX + root.Doc.bodyStartX) - root.Doc.scrollX, endY
+
 }
 
 // findColumnRange returns the start and end of the column range containing contentX, or ok=false if not found.

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -244,12 +244,18 @@ func TestRoot_Run(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewOviewer error = %v", err)
 			}
+
+			done := make(chan error, 1)
 			go func() {
-				if err := root.Run(); (err != nil) != tt.wantErr {
-					t.Errorf("Root.Run() error = %v, wantErr %v", err, tt.wantErr)
-				}
+				done <- root.Run()
 			}()
+
 			root.Quit(context.Background())
+
+			runErr := <-done
+			if (runErr != nil) != tt.wantErr {
+				t.Errorf("Root.Run() error = %v, wantErr %v", runErr, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Fixed an issue where mouse selection was offset when horizontally scrolled by properly accounting for scrollX in selection calculations.
- Corrected wrapNum increment logic to only increment when WrapMode is enabled, preventing incorrect behavior when WrapMode is off.