### PR TITLE
Fix shrink width handling in align converter

### DIFF
--- a/oviewer/convert_align.go
+++ b/oviewer/convert_align.go
@@ -173,7 +173,6 @@ func (a *align) convertWidth(src contents) contents {
 		if a.isShrink(columnNum) {
 			dst = appendShrink(dst)
 			dst = append(dst, SpaceContent)
-			a.maxWidths[columnNum] = uniseg.StringWidth(string(Shrink))
 			start = end
 			continue
 		}

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -204,6 +204,12 @@ func (root *Root) setAlignConverter() {
 		maxWidths, addRight = m.maxColumnWidths(maxWidths, addRight, ln)
 	}
 
+	// Apply shrink width to shrunk columns before comparing.
+	for i, attr := range m.alignConv.columnAttrs {
+		if i < len(maxWidths) && attr.shrink {
+			maxWidths[i] = ShrinkContent.width
+		}
+	}
 	if slices.Equal(m.alignConv.maxWidths, maxWidths) {
 		return
 	}


### PR DESCRIPTION
When calculating the maximum widths for columns in the align converter, the shrink width should be applied to columns that are marked as shrink. This ensures that the maximum widths reflect the actual width of shrunk columns, which is necessary for correct layout and rendering.