### PR TITLE
Replace "clear lines" with "clear(lines)" and improve comments

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -100,7 +100,7 @@ type Document struct {
 	// columnWidths is a slice of column widths.
 	columnWidths []int
 
-	// RunTimeSettings contains RunTimeSettings settings.
+	// RunTimeSettings contains runtime configuration options for the document.
 	RunTimeSettings
 
 	// memoryLimit is the maximum chunk size.
@@ -638,7 +638,7 @@ func (m *Document) watchMode() {
 	m.FollowSection = true
 }
 
-// unwatchMode unwatch mode for the document.
+// unwatchMode disables watch mode for the document.
 func (m *Document) unwatchMode() {
 	m.WatchMode = false
 	m.FollowSection = false

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -599,8 +599,9 @@ func needsDisplaySync(str string) bool {
 		if runewidth.IsAmbiguousWidth(mainc) {
 			return true
 		}
-		// Regional indicator symbols and emoji range that commonly cause issues
-		// Check for regional indicator symbols (used in flag emojis).
+		// Emoji and symbol ranges that commonly cause display width issues.
+		// Covers regional indicators (🇦-🇿), misc symbols, pictographs, emoticons,
+		// transport symbols, and supplemental symbols (U+1F1E0..U+1F9FF).
 		if mainc >= 0x1F1E0 && mainc <= 0x1F9FF {
 			return true
 		}

--- a/oviewer/draw_test.go
+++ b/oviewer/draw_test.go
@@ -702,7 +702,7 @@ func TestRoot_drawSelect_reversePointsDoesNotPanic(t *testing.T) {
 	root.Doc.bodyWidth = 10
 	root.Doc.Style.SelectActive = OVStyle{Reverse: true}
 
-	for y := 0; y < 5; y++ {
+	for y := range 5 {
 		for x := 0; x < root.Doc.bodyWidth; x++ {
 			root.Screen.Put(x, y, "x", tcell.StyleDefault)
 		}

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -408,10 +408,7 @@ func (m *Document) getHeight(startLN int, endLN int) int {
 
 // prepareLines returns the contents of the screen.
 func (root *Root) prepareLines(lines map[int]LineC) map[int]LineC {
-	// clear lines.
-	for k := range lines {
-		delete(lines, k)
-	}
+	clear(lines)
 	// Header.
 	lines = root.setLines(lines, root.scr.headerLN, root.scr.headerEnd)
 	// Section header.
@@ -673,7 +670,7 @@ func findColumnEnd(lc contents, indexes []int, n int, start int) int {
 	return rPos
 }
 
-// findPrevSpace returns the position just before the previous space.
+// findPrevSpace returns the position of the previous space.
 func findPrevSpace(lc contents, start int) int {
 	for p := start; p > 0; p-- {
 		if lc.IsSpace(p) {


### PR DESCRIPTION
Replace "clear lines" with "clear(lines)" and improve comments in the prepareLines function.