### PR TITLE
feat: add generate-config output for default/less templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/noborus/ov/oviewer"
@@ -46,6 +48,8 @@ var (
 	listViewMode bool
 	// completion is the generation of shell completion.
 	completion string
+	// generateConfig is the generation of configuration file content.
+	generateConfig string
 	// execCommand targets the output of executing the command.
 	execCommand bool
 
@@ -61,6 +65,11 @@ var (
 	// ErrMissingFile indicates that the file is missing.
 	ErrMissingFile = errors.New("missing file")
 )
+
+const keybindTag = "{{KEYBIND}}"
+
+//go:embed ov.yaml.template
+var configTemplate string
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -96,6 +105,10 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 		if completion != "" {
 			return Completion(cmd, completion)
 		}
+
+		if generateConfig != "" {
+			return GenerateConfig(generateConfig)
+		}
 		// Set a global variable to convert to a style before opening the file.
 		oviewer.OverStrikeStyle = oviewer.ToTcellStyle(config.StyleOverStrike)
 		oviewer.OverLineStyle = oviewer.ToTcellStyle(config.StyleOverLine)
@@ -112,6 +125,53 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 		}
 		return RunOviewer(args)
 	},
+}
+
+// GenerateConfig writes generated config to stdout.
+// mode supports "default" and "less".
+func GenerateConfig(mode string) error {
+	content, err := renderConfigTemplate(mode)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(os.Stdout, content)
+	return err
+}
+
+func renderConfigTemplate(mode string) (string, error) {
+	var keyBind oviewer.KeyBind
+	switch mode {
+	case "less":
+		keyBind = oviewer.LessKeyBinds()
+	default:
+		keyBind = oviewer.DefaultKeyBinds()
+	}
+
+	generated := generateKeyBindSection(keyBind)
+	if !strings.Contains(configTemplate, keybindTag) {
+		return "", fmt.Errorf("template tag %q not found", keybindTag)
+	}
+
+	return strings.Replace(configTemplate, keybindTag, generated, 1), nil
+}
+
+func generateKeyBindSection(keyBind oviewer.KeyBind) string {
+	keys := make([]string, 0, len(keyBind))
+	for k := range keyBind {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	var sb strings.Builder
+	sb.WriteString("KeyBind:\n")
+	for _, action := range keys {
+		vals := keyBind[action]
+		fmt.Fprintf(&sb, "    %s:\n", action)
+		for _, v := range vals {
+			fmt.Fprintf(&sb, "        - %q\n", v)
+		}
+	}
+	return sb.String()
 }
 
 // HelpKey displays key bindings and exits.
@@ -391,6 +451,10 @@ func init() {
 	_ = rootCmd.RegisterFlagCompletionFunc("completion", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"bash", "zsh", "fish", "powershell"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	rootCmd.PersistentFlags().StringVar(&generateConfig, "generate-config", "", "generate configuration [default|less]")
+	_ = rootCmd.RegisterFlagCompletionFunc("generate-config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"default", "less"}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	rootCmd.PersistentFlags().StringVarP(&pattern, "pattern", "", "", "search pattern")
 	rootCmd.PersistentFlags().StringVarP(&filter, "filter", "", "", "filter search pattern")
@@ -581,6 +645,10 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	if generateConfig != "" {
+		return
+	}
+
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)

--- a/main_test.go
+++ b/main_test.go
@@ -148,10 +148,12 @@ func TestRootCmd_FlagFAndFilter(t *testing.T) {
 	origConfig := config
 	origFilter := filter
 	origCfgFile := cfgFile
+	origGenerateConfig := generateConfig
 	t.Cleanup(func() {
 		config = origConfig
 		filter = origFilter
 		cfgFile = origCfgFile
+		generateConfig = origGenerateConfig
 	})
 
 	config = oviewer.NewConfig()
@@ -168,5 +170,78 @@ func TestRootCmd_FlagFAndFilter(t *testing.T) {
 	}
 	if filter != "ok" {
 		t.Errorf("filter = %q, want %q", filter, "ok")
+	}
+}
+
+func TestRenderConfigTemplate(t *testing.T) {
+	content, err := renderConfigTemplate("default")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate() error = %v", err)
+	}
+
+	if strings.Contains(content, keybindTag) {
+		t.Fatalf("rendered content contains unresolved tag %q", keybindTag)
+	}
+	if !strings.Contains(content, "KeyBind:\n") {
+		t.Fatalf("rendered content does not contain KeyBind section")
+	}
+}
+
+func TestRenderConfigTemplate_Mode(t *testing.T) {
+	defaultContent, err := renderConfigTemplate("default")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate(default) error = %v", err)
+	}
+
+	lessContent, err := renderConfigTemplate("less")
+	if err != nil {
+		t.Fatalf("renderConfigTemplate(less) error = %v", err)
+	}
+
+	if defaultContent == lessContent {
+		t.Fatalf("rendered content for default and less should be different")
+	}
+}
+
+func TestRootCmd_GenerateConfigStdout(t *testing.T) {
+	origGenerateConfig := generateConfig
+	origVer := ver
+	origStdout := os.Stdout
+	origCfgFile := cfgFile
+	t.Cleanup(func() {
+		generateConfig = origGenerateConfig
+		ver = origVer
+		os.Stdout = origStdout
+		cfgFile = origCfgFile
+	})
+
+	cfgFile = ""
+	ver = false
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	os.Stdout = w
+
+	rootCmd.SetArgs([]string{"--generate-config", "default"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() error = %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("Copy() error = %v", err)
+	}
+
+	got := buf.String()
+	if strings.Contains(got, keybindTag) {
+		t.Fatalf("generated output contains unresolved tag %q", keybindTag)
+	}
+	if !strings.Contains(got, "KeyBind:\n") {
+		t.Fatalf("generated output does not contain KeyBind section")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -217,23 +217,29 @@ func TestRootCmd_GenerateConfigStdout(t *testing.T) {
 
 	cfgFile = ""
 	ver = false
-	r, w, err := os.Pipe()
+	
+	// Create a temporary file to capture stdout
+	tmpFile, err := os.CreateTemp("", "test-stdout-*.txt")
 	if err != nil {
-		t.Fatalf("Pipe() error = %v", err)
+		t.Fatalf("CreateTemp() error = %v", err)
 	}
-	os.Stdout = w
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+	
+	os.Stdout = tmpFile
 
 	rootCmd.SetArgs([]string{"--generate-config", "default"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("rootCmd.Execute() error = %v", err)
 	}
 
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+	// Seek back to the beginning to read the content
+	if _, err := tmpFile.Seek(0, 0); err != nil {
+		t.Fatalf("Seek() error = %v", err)
 	}
 
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
+	if _, err := io.Copy(&buf, tmpFile); err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
 


### PR DESCRIPTION
- add --generate-config flag with default|less completion
- embed ov.yaml.template and replace {{KEYBIND}} with generated key bindings
- sort keybind actions for stable output
- skip config loading when config generation mode is enabled
- add tests for template rendering, mode differences, and stdout output

```console
ov --generate-config default > ov.yaml
```


```console
ov --generate-config less > ov.yaml
```