### PR TITLE
Upgrade tcell/v3 to v3.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/gdamore/tcell/v3 v3.3.0
+	github.com/gdamore/tcell/v3 v3.4.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jwalton/gchalk v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
-github.com/gdamore/tcell/v3 v3.3.0 h1:lGo3VwiV8iYMH4TdwBDwEOoDctnOLns6QfrXvZkKNe8=
-github.com/gdamore/tcell/v3 v3.3.0/go.mod h1:8CJpEjUiAlFIrs7jUhzobiZsSLBAtXo8Dq9mCTrVnqo=
+github.com/gdamore/tcell/v3 v3.4.0 h1:VUym1HQZiYodA5PGQrqLxF7QwqQndcAUwQD7G7XUy5E=
+github.com/gdamore/tcell/v3 v3.4.0/go.mod h1:fjKxNiIFwbzTxDU+i+AAMz+xPOgXVaZq5tbShsKseHc=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/oviewer/example_test.go
+++ b/oviewer/example_test.go
@@ -17,7 +17,7 @@ const cwd = ".."
 var testdata = filepath.Join(cwd, "testdata")
 
 // fakeScreen returns a fake screen.
-func fakeScreen() (tcell.Screen, error) {
+func fakeScreen(opts ...tcell.TerminfoScreenOption) (tcell.Screen, error) {
 	// width, height := 80, 25
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 25})
 	return tcell.NewTerminfoScreenFromTty(mt)

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -310,7 +310,7 @@ var tcellNewScreen = tcell.NewScreen
 // SetTcellNewScreen sets the function to create a new tcell screen.
 // This is used for testing purposes to replace the tcell.NewScreen function.
 // It allows for mocking the screen creation in tests.
-func SetTcellNewScreen(f func() (tcell.Screen, error)) {
+func SetTcellNewScreen(f func(opts ...tcell.TerminfoScreenOption) (tcell.Screen, error)) {
 	tcellNewScreen = f
 }
 

--- a/oviewer/oviewer_test.go
+++ b/oviewer/oviewer_test.go
@@ -19,7 +19,7 @@ const cwd = ".."
 var testdata = filepath.Join(cwd, "testdata")
 
 // fakeScreen returns a fake screen.
-func fakeScreen() (tcell.Screen, error) {
+func fakeScreen(opts ...tcell.TerminfoScreenOption) (tcell.Screen, error) {
 	// width, height := 80, 25
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 25})
 	return tcell.NewTerminfoScreenFromTty(mt)


### PR DESCRIPTION
Update dependencies to tcell v3.4.0 and adapt function signatures to support the new TerminfoScreenOption parameter:
- Update fakeScreen() function signatures to accept TerminfoScreenOption
- Update SetTcellNewScreen() to match the new screen creation interface