### PR TITLE
Enhance incremental input for search, filter, and multicolor features

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -654,16 +654,37 @@ func (root *Root) updateSectionList(ctx context.Context, sections MatchedLineLis
 
 // setMultiColor set multiple strings to highlight with multiple colors.
 func (root *Root) setMultiColor(input string) {
+	root.Doc.setMultiColorWords(parseMultiColorWords(input))
+	root.setMessagef("Set multicolor strings [%s]", input)
+}
+
+// parseMultiColorWords parses multi color words from input while preserving quoted groups.
+func parseMultiColorWords(input string) []string {
 	quoted := false
-	f := strings.FieldsFunc(input, func(r rune) bool {
+	fields := strings.FieldsFunc(input, func(r rune) bool {
 		if r == '"' {
 			quoted = !quoted
 		}
 		return !quoted && r == ' '
 	})
+	for i, v := range fields {
+		fields[i] = strings.Trim(v, "\"")
+	}
+	return fields
+}
 
-	root.Doc.setMultiColorWords(f)
-	root.setMessagef("Set multicolor strings [%s]", input)
+// formatMultiColorWords formats words for the multicolor input field.
+// Words containing spaces are wrapped in double quotes so they round-trip through parseMultiColorWords.
+func formatMultiColorWords(words []string) string {
+	formatted := make([]string, len(words))
+	for i, word := range words {
+		if strings.ContainsRune(word, ' ') {
+			formatted[i] = "\"" + word + "\""
+			continue
+		}
+		formatted[i] = word
+	}
+	return strings.Join(formatted, " ")
 }
 
 // setJumpTarget sets the position of the search result.

--- a/oviewer/input.go
+++ b/oviewer/input.go
@@ -109,7 +109,7 @@ func (root *Root) inputEvent(ctx context.Context, ev *tcell.EventKey) {
 	defer root.afterInputEvent(ctx)
 	evKey := root.inputCapture(ev)
 	if ok := root.input.keyEvent(evKey); !ok {
-		root.incrementalSearch(ctx)
+		root.incrementalInput(ctx)
 		return
 	}
 
@@ -123,6 +123,24 @@ func (root *Root) inputEvent(ctx context.Context, ev *tcell.EventKey) {
 	nev := input.Event.Confirm(input.value)
 	root.postEvent(nev)
 	input.Event = normal()
+}
+
+// incrementalInput performs incremental processing while editing input.
+// Search keeps existing incremental behavior, and MultiColor updates highlights in real time.
+// Filter updates search highlight only without performing actual filtering.
+func (root *Root) incrementalInput(ctx context.Context) {
+	mode := root.input.Event.Mode()
+
+	switch mode {
+	case Search:
+		root.incSearch(ctx, true)
+	case Backsearch:
+		root.incSearch(ctx, false)
+	case Filter:
+		root.setSearcher(root.input.value, root.Config.CaseSensitive)
+	case MultiColor:
+		root.Doc.setMultiColorWords(parseMultiColorWords(root.input.value))
+	}
 }
 
 // afterInputEvent is called after processing an input event.

--- a/oviewer/input_incremental_test.go
+++ b/oviewer/input_incremental_test.go
@@ -1,0 +1,89 @@
+package oviewer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestParseMultiColorWords(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "space split",
+			input: "error info warn",
+			want:  []string{"error", "info", "warn"},
+		},
+		{
+			name:  "quoted word",
+			input: "error \"warn notice\"",
+			want:  []string{"error", "warn notice"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseMultiColorWords(tt.input); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseMultiColorWords() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMultiColorWords(t *testing.T) {
+	tests := []struct {
+		name  string
+		words []string
+		want  string
+	}{
+		{
+			name:  "without spaces",
+			words: []string{"error", "warn", "info"},
+			want:  "error warn info",
+		},
+		{
+			name:  "with spaces",
+			words: []string{"error", "warn notice", "panic"},
+			want:  "error \"warn notice\" panic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatMultiColorWords(tt.words); got != tt.want {
+				t.Fatalf("formatMultiColorWords() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultiColorWordsParseFormatRoundTrip(t *testing.T) {
+	words := []string{"error", "warn notice", "debug"}
+	formatted := formatMultiColorWords(words)
+	if got := parseMultiColorWords(formatted); !reflect.DeepEqual(got, words) {
+		t.Fatalf("parseMultiColorWords(formatMultiColorWords()) = %v, want %v", got, words)
+	}
+}
+
+func TestRoot_incrementalInput_filterSearchHighlight(t *testing.T) {
+	root := rootHelper(t)
+	root.Config.CaseSensitive = false
+
+	root.input.Event = newSearchEvent(root.input.Candidate[Search], filter)
+	root.input.value = "test"
+
+	root.incrementalInput(context.Background())
+
+	// Check that searcher is set (not nil)
+	if root.searcher == nil {
+		t.Fatalf("incrementalInput Filter: searcher should be set, got nil")
+	}
+
+	// Check that searcher string matches input value
+	if got, want := root.searcher.String(), "test"; got != want {
+		t.Fatalf("incrementalInput Filter: searcher string = %v, want %v", got, want)
+	}
+}

--- a/oviewer/input_multicolor.go
+++ b/oviewer/input_multicolor.go
@@ -2,7 +2,6 @@ package oviewer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -16,10 +15,10 @@ func (root *Root) inputMultiColor(context.Context) {
 	input.reset()
 
 	searches := root.input.searchCandidates(searchCandidateListLen)
-	input.Candidate[MultiColor].toLast(strings.Join(searches, " "))
+	input.Candidate[MultiColor].toLast(formatMultiColorWords(searches))
 	old := root.Doc.MultiColorWords
-	input.Candidate[MultiColor].toLast(strings.Join(old, " "))
-	input.Event = newMultiColorEvent(input.Candidate[MultiColor])
+	input.Candidate[MultiColor].toLast(formatMultiColorWords(old))
+	input.Event = newMultiColorEvent(input.Candidate[MultiColor], old)
 }
 
 // multiColorCandidate returns the candidate to set to default.
@@ -35,13 +34,18 @@ func multiColorCandidate() *candidate {
 // eventMultiColor represents the multi color input mode.
 type eventMultiColor struct {
 	tcell.EventTime
-	clist *candidate
-	value string
+	clist         *candidate
+	value         string
+	originalWords []string
 }
 
 // newMultiColorEvent returns multiColorEvent.
-func newMultiColorEvent(clist *candidate) *eventMultiColor {
-	return &eventMultiColor{clist: clist}
+func newMultiColorEvent(clist *candidate, originalWords ...[]string) *eventMultiColor {
+	e := &eventMultiColor{clist: clist}
+	if len(originalWords) > 0 {
+		e.originalWords = append([]string(nil), originalWords[0]...)
+	}
+	return e
 }
 
 // Mode returns InputMode.

--- a/oviewer/input_multicolor.go
+++ b/oviewer/input_multicolor.go
@@ -18,7 +18,7 @@ func (root *Root) inputMultiColor(context.Context) {
 	input.Candidate[MultiColor].toLast(formatMultiColorWords(searches))
 	old := root.Doc.MultiColorWords
 	input.Candidate[MultiColor].toLast(formatMultiColorWords(old))
-	input.Event = newMultiColorEvent(input.Candidate[MultiColor], old)
+	input.Event = newMultiColorEvent(input.Candidate[MultiColor])
 }
 
 // multiColorCandidate returns the candidate to set to default.
@@ -34,18 +34,13 @@ func multiColorCandidate() *candidate {
 // eventMultiColor represents the multi color input mode.
 type eventMultiColor struct {
 	tcell.EventTime
-	clist         *candidate
-	value         string
-	originalWords []string
+	clist *candidate
+	value string
 }
 
 // newMultiColorEvent returns multiColorEvent.
-func newMultiColorEvent(clist *candidate, originalWords ...[]string) *eventMultiColor {
-	e := &eventMultiColor{clist: clist}
-	if len(originalWords) > 0 {
-		e.originalWords = append([]string(nil), originalWords[0]...)
-	}
-	return e
+func newMultiColorEvent(clist *candidate) *eventMultiColor {
+	return &eventMultiColor{clist: clist}
 }
 
 // Mode returns InputMode.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -237,11 +237,11 @@ func (root *Root) createSearcher(word string, caseSensitive bool) Searcher {
 
 // setSearcher sets root.searcher using createSearcher and updates input.value.
 func (root *Root) setSearcher(word string, caseSensitive bool) Searcher {
+	root.input.value = word
 	if word == "" {
 		root.searcher = nil
 		return nil
 	}
-	root.input.value = word
 	searcher := root.createSearcher(word, caseSensitive)
 	root.searcher = searcher
 	return searcher
@@ -529,29 +529,18 @@ func (root *Root) sendSearchMove(lineNum int, searcher Searcher) {
 	root.postEvent(ev)
 }
 
-// incrementalSearch performs incremental search by setting and input mode.
-func (root *Root) incrementalSearch(ctx context.Context) {
-	if !root.Config.Incsearch {
-		return
-	}
-
-	switch root.input.Event.Mode() {
-	case Search:
-		root.incSearch(ctx, true, root.startSearchLN())
-	case Backsearch:
-		root.incSearch(ctx, false, root.startSearchLN())
-	}
-}
-
 // incSearch implements incremental forward/back search.
-func (root *Root) incSearch(ctx context.Context, forward bool, lineNum int) {
+func (root *Root) incSearch(ctx context.Context, forward bool) {
 	root.Doc.topLN = root.returnStartPosition()
-
 	searcher := root.setSearcher(root.input.value, root.Config.CaseSensitive)
 	if searcher == nil {
 		return
 	}
+	if !root.Config.Incsearch {
+		return
+	}
 
+	lineNum := root.startSearchLN()
 	ctx = root.cancelRestart(ctx)
 	go func() {
 		n, err := root.Doc.searchLine(ctx, searcher, forward, lineNum)

--- a/oviewer/search_test.go
+++ b/oviewer/search_test.go
@@ -1084,7 +1084,6 @@ func TestRoot_incSearch(t *testing.T) {
 	}
 	type args struct {
 		forward bool
-		lineNum int
 	}
 	tests := []struct {
 		name   string
@@ -1100,7 +1099,6 @@ func TestRoot_incSearch(t *testing.T) {
 			},
 			args: args{
 				forward: true,
-				lineNum: 0,
 			},
 		},
 	}
@@ -1111,7 +1109,7 @@ func TestRoot_incSearch(t *testing.T) {
 			root.input.value = tt.fields.word
 			root.prepareScreen()
 			ctx := context.Background()
-			root.incSearch(ctx, tt.args.forward, tt.args.lineNum)
+			root.incSearch(ctx, tt.args.forward)
 			root.returnStartPosition()
 			if got := root.Doc.topLN; got != tt.fields.topLN {
 				t.Errorf("Root.returnStartPosition() = %v, want %v", got, tt.fields.topLN)


### PR DESCRIPTION
- add incrementalInput to handle Search, Backsearch, Filter, and MultiColor modes while editing
- update incSearch to derive the start line internally and gate async jump by Incsearch
- ensure setSearcher always syncs input value, even when clearing the searcher
- extract multicolor word parsing/formatting with quoted phrase support for round-trip input
- preserve original multicolor words in multiColor event initialization
- add tests for multicolor parse/format round-trip and incremental filter highlight setup