### PR TITLE
Add an explanation of style suppression settings

### DIFF
--- a/indexmap/indexmap.go
+++ b/indexmap/indexmap.go
@@ -12,6 +12,7 @@ type IndexMap[k comparable, v comparable] struct {
 	values map[k]v
 }
 
+// NewIndexMap creates and returns a new IndexMap instance.
 func NewIndexMap[k comparable, v comparable]() *IndexMap[k, v] {
 	return &IndexMap[k, v]{}
 }
@@ -121,6 +122,28 @@ func (m *IndexMap[k, v]) Values() iter.Seq[v] {
 				return
 			}
 		}
+	}
+}
+
+// SetValues sets values for keys in insertion order.
+// If there are more values than keys, the extra values are ignored.
+// If there are fewer values than keys, the remaining keys are set to the zero value of v.
+func (m *IndexMap[k, v]) SetValues(slice []v) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.values == nil {
+		m.values = make(map[k]v)
+	}
+	for i, v := range slice {
+		var zeroK k
+		if i < len(m.keys) {
+			zeroK = m.keys[i]
+		} else {
+			zeroK = *new(k)
+			m.keys = append(m.keys, zeroK)
+		}
+		m.values[zeroK] = v
 	}
 }
 

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -65,6 +65,8 @@ type Document struct {
 
 	// styles is a set of tcell styles used in the document.
 	styles *indexmap.IndexMap[tcell.Style, bool]
+	// backupStyleFlags is a backup of the style flags for toggling styles.
+	backupStyleFlags []bool
 	// isStylesEnabled indicates whether styles are enabled or disabled.
 	isStylesEnabled bool
 

--- a/oviewer/input_styletoggle.go
+++ b/oviewer/input_styletoggle.go
@@ -11,7 +11,23 @@ func (root *Root) inputStyleToggle(ctx context.Context) {
 	root.openSidebar(ctx, SidebarModeStyles)
 	input := root.input
 	input.reset()
+	root.backupStyleFlags()
 	input.Event = newStyleToggleEvent(input.Candidate[StyleToggle])
+}
+
+// backupStyleFlags backs up the current style flags.
+func (root *Root) backupStyleFlags() {
+	if root.Doc.styles.Len() == 0 {
+		return
+	}
+	root.Doc.backupStyleFlags = make([]bool, root.Doc.styles.Len())
+	for i := 0; i < root.Doc.styles.Len(); i++ {
+		_, b, ok := root.Doc.styles.Index(i)
+		if !ok {
+			continue
+		}
+		root.Doc.backupStyleFlags[i] = b
+	}
 }
 
 // eventStyleToggle represents the style highlight suppression input mode.

--- a/oviewer/sidebar.go
+++ b/oviewer/sidebar.go
@@ -247,10 +247,10 @@ func (root *Root) sidebarItemsForStyles() []SidebarItem {
 	var items []SidebarItem
 	length := root.sidebarWidth - 4
 	helpLines := []string{
-		"number or token (separated by ,):",
-		"n: disable all, a: enable all, i: invert all",
-		"1-3: toggle 1 to 3",
-		"o1: disable all then toggle 1",
+		"number or command to select style:",
+		"o: disable all (e.g. o1)",
+		"a: enable all (e.g. a1-2)",
+		"i: invert all (e.g. i1,3)",
 	}
 	helpStyle := tcell.StyleDefault.Foreground(color.Green)
 	totalLines := root.Doc.styles.Len() + len(helpLines)

--- a/oviewer/sidebar.go
+++ b/oviewer/sidebar.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 )
 
 // SidebarItem represents an item to display in the sidebar.
@@ -245,16 +246,36 @@ func (root *Root) sidebarItemsForViewMode() []SidebarItem {
 func (root *Root) sidebarItemsForStyles() []SidebarItem {
 	var items []SidebarItem
 	length := root.sidebarWidth - 4
-	styleNames := make([]tcell.Style, 0, root.Doc.styles.Len())
-	for style := range root.Doc.styles.Keys() {
-		styleNames = append(styleNames, style)
+	helpLines := []string{
+		"number or token (separated by ,):",
+		"n: disable all, a: enable all, i: invert all",
+		"1-3: toggle 1 to 3",
+		"o1: disable all then toggle 1",
 	}
-	root.adjustSidebarScroll(SidebarModeStyles, len(styleNames), 0)
+	helpStyle := tcell.StyleDefault.Foreground(color.Green)
+	totalLines := root.Doc.styles.Len() + len(helpLines)
+	root.adjustSidebarScroll(SidebarModeStyles, totalLines, 0)
 	scroll := root.sidebarScrolls[SidebarModeStyles]
 	start := scroll.y
-	end := min(start+root.scr.vHeight, len(styleNames))
+	end := min(start+root.scr.vHeight, totalLines)
 	for i := start; i < end; i++ {
-		style, enabled, ok := root.Doc.styles.Index(i)
+		if i < len(helpLines) {
+			displayName := StrToContents(helpLines[i], 0)
+			if len(displayName) < length {
+				spaces := StrToContents(strings.Repeat(" ", length-len(displayName)), 0)
+				displayName = append(displayName, spaces...)
+			}
+			items = append(items, SidebarItem{
+				Label:        "",
+				Contents:     displayName,
+				IsCurrent:    false,
+				ContentStyle: &helpStyle,
+			})
+			continue
+		}
+
+		styleIndex := i - len(helpLines)
+		style, enabled, ok := root.Doc.styles.Index(styleIndex)
 		if !ok {
 			break
 		}
@@ -267,7 +288,7 @@ func (root *Root) sidebarItemsForStyles() []SidebarItem {
 			spaces := StrToContents(strings.Repeat(" ", length-len(displayName)), 0)
 			displayName = append(displayName, spaces...)
 		}
-		label := fmt.Sprintf("%2d ", i)
+		label := fmt.Sprintf("%2d ", styleIndex)
 		items = append(items, SidebarItem{
 			Label:        label,
 			Contents:     displayName,
@@ -286,30 +307,17 @@ func styleString(style tcell.Style) string {
 	defaultBG := tcell.StyleDefault.GetBackground()
 	defaultAttrs := tcell.StyleDefault.GetAttributes()
 
-	fgDiff := fg != defaultFG
-	bgDiff := bg != defaultBG
-	attrsDiff := attrs != defaultAttrs
-
-	switch {
-	case !fgDiff && !bgDiff && !attrsDiff:
-		return "Default"
-	case fgDiff && !bgDiff && !attrsDiff:
-		return fmt.Sprintf("FG=%v", fg.String())
-	case !fgDiff && bgDiff && !attrsDiff:
-		return fmt.Sprintf("BG=%v", bg.String())
-	default:
-		parts := make([]string, 0, 3)
-		if fgDiff {
-			parts = append(parts, fmt.Sprintf("FG=%v", fg.String()))
-		}
-		if bgDiff {
-			parts = append(parts, fmt.Sprintf("BG=%v", bg.String()))
-		}
-		if attrsDiff {
-			parts = append(parts, fmt.Sprintf("ATTRS=0x%x", int64(attrs)))
-		}
-		return strings.Join(parts, ", ")
+	parts := make([]string, 0, 3)
+	if fg != defaultFG {
+		parts = append(parts, fmt.Sprintf("FG=%v", fg.String()))
 	}
+	if bg != defaultBG {
+		parts = append(parts, fmt.Sprintf("BG=%v", bg.String()))
+	}
+	if attrs != defaultAttrs {
+		parts = append(parts, fmt.Sprintf("ATTRS=0x%x", int64(attrs)))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // sidebarUp scrolls the sidebar up.

--- a/oviewer/style_stats.go
+++ b/oviewer/style_stats.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 )
 
-// validateStyle is a placeholder function for confirming the style input.
+// validateStyle confirms the style input and applies the selection.
 func (root *Root) validateStyle(input string) {
-	// This function is currently a placeholder and does not perform any validation.
+	root.Doc.applyStyleSelection(input)
 }
 
 // applyStyleSelection toggles the style based on the provided value.
 func (m *Document) applyStyleSelection(input string) {
+	m.styles.SetValues(m.backupStyleFlags) // Restore backup flags before applying new selection.
 	stylesLen := m.styles.Len()
 	if stylesLen == 0 {
 		return
@@ -40,23 +41,18 @@ func parseInputStyles(input string) ([]string, bool) {
 
 // applyStyleToken processes a single token to toggle styles based on the defined rules.
 func (m *Document) applyStyleToken(token string, stylesLen int) {
-	switch token {
-	case "a":
-		m.enableAllStyles()
-		return
-	case "n":
-		m.disableAllStyles()
-		return
-	case "i":
-		m.toggleAllStyles()
+	if token == "" {
 		return
 	}
-
-	if strings.HasPrefix(token, "o") {
+	firstChar := token[:1]
+	switch firstChar {
+	case "i":
+		token = token[1:]
+		m.toggleAllStyles()
+	case "o":
 		token = token[1:]
 		m.disableAllStyles()
-	}
-	if strings.HasPrefix(token, "t") {
+	case "a":
 		token = token[1:]
 		m.enableAllStyles()
 	}


### PR DESCRIPTION
Add an explanation of style suppression settings in the sidebar, including instructions on how to toggle styles using numbers or tokens. This will help users understand how to manage their styles effectively.