### PR TITLE
refactor(style-stats): move and enrich style string formatting; add ANSI coverage test

### DIFF
--- a/oviewer/sidebar.go
+++ b/oviewer/sidebar.go
@@ -247,10 +247,10 @@ func (root *Root) sidebarItemsForStyles() []SidebarItem {
 	var items []SidebarItem
 	length := root.sidebarWidth - 4
 	helpLines := []string{
-		"number or command to select style:",
-		"o: disable all (e.g. o1)",
-		"a: enable all (e.g. a1-2)",
-		"i: invert all (e.g. i1,3)",
+		"Toggle styles with the following commands:",
+		"o: disable all (e.g., o1)",
+		"a: enable all (e.g., a1-2)",
+		"i: invert all (e.g., i1,3)",
 	}
 	helpStyle := tcell.StyleDefault.Foreground(color.Green)
 	totalLines := root.Doc.styles.Len() + len(helpLines)
@@ -297,27 +297,6 @@ func (root *Root) sidebarItemsForStyles() []SidebarItem {
 		})
 	}
 	return items
-}
-
-func styleString(style tcell.Style) string {
-	fg := style.GetForeground()
-	bg := style.GetBackground()
-	attrs := style.GetAttributes()
-	defaultFG := tcell.StyleDefault.GetForeground()
-	defaultBG := tcell.StyleDefault.GetBackground()
-	defaultAttrs := tcell.StyleDefault.GetAttributes()
-
-	parts := make([]string, 0, 3)
-	if fg != defaultFG {
-		parts = append(parts, fmt.Sprintf("FG=%v", fg.String()))
-	}
-	if bg != defaultBG {
-		parts = append(parts, fmt.Sprintf("BG=%v", bg.String()))
-	}
-	if attrs != defaultAttrs {
-		parts = append(parts, fmt.Sprintf("ATTRS=0x%x", int64(attrs)))
-	}
-	return strings.Join(parts, ", ")
 }
 
 // sidebarUp scrolls the sidebar up.

--- a/oviewer/style_stats.go
+++ b/oviewer/style_stats.go
@@ -118,71 +118,70 @@ func (m *Document) toggleStyleIdx(idx int) {
 	m.styles.Set(k, !v)
 }
 
+// styleString returns a string representation of the given tcell.Style, including its foreground color, background color, attributes, and underline style.
 func styleString(style tcell.Style) string {
-	fg := style.GetForeground()
-	bg := style.GetBackground()
-	attrs := style.GetAttributes()
-	uStyle := style.GetUnderlineStyle()
-	uColor := style.GetUnderlineColor()
-	defaultFG := tcell.StyleDefault.GetForeground()
-	defaultBG := tcell.StyleDefault.GetBackground()
-	defaultAttrs := tcell.StyleDefault.GetAttributes()
-
 	parts := make([]string, 0, 3)
-	if fg != defaultFG {
-		parts = append(parts, fmt.Sprintf("FG=%v", fg.String()))
+
+	fg := style.GetForeground()
+	if fg != tcell.ColorDefault {
+		parts = append(parts, fmt.Sprintf("FG=%v", fg))
 	}
-	if bg != defaultBG {
-		parts = append(parts, fmt.Sprintf("BG=%v", bg.String()))
+
+	bg := style.GetBackground()
+	if bg != tcell.ColorDefault {
+		parts = append(parts, fmt.Sprintf("BG=%v", bg))
 	}
-	if attrs != defaultAttrs {
-		parts = append(parts, fmt.Sprintf("%v", attrString(attrs)))
+
+	if style.HasBold() {
+		parts = append(parts, "Bold")
 	}
-	if uStyle != tcell.UnderlineStyleNone {
-		parts = append(parts, fmt.Sprintf("%v", ustyleString(uStyle)))
+	if style.HasBlink() {
+		parts = append(parts, "Blink")
 	}
-	if uColor != defaultFG {
-		parts = append(parts, fmt.Sprintf("UnderlineColor=%v", uColor.String()))
+	if style.HasReverse() {
+		parts = append(parts, "Reverse")
+	}
+	if style.HasDim() {
+		parts = append(parts, "Dim")
+	}
+	if style.HasItalic() {
+		parts = append(parts, "Italic")
+	}
+	if style.HasStrikeThrough() {
+		parts = append(parts, "StrikeThrough")
+	}
+	if style.HasUnderline() {
+		parts = append(parts, underlineString(style))
 	}
 	return strings.Join(parts, ", ")
 }
 
-func attrString(attrs tcell.AttrMask) string {
-	var parts []string
-	if attrs&tcell.AttrBold != 0 {
-		parts = append(parts, "Bold")
+func underlineString(style tcell.Style) string {
+	uStyle := style.GetUnderlineStyle()
+	if uStyle != tcell.UnderlineStyleNone {
+		uline := "Underline" + ustyleString(uStyle)
+		uColor := style.GetUnderlineColor()
+		if uColor != tcell.ColorDefault {
+			uline += fmt.Sprintf("(%v)", uColor)
+		}
+		return uline
 	}
-	if attrs&tcell.AttrBlink != 0 {
-		parts = append(parts, "Blink")
-	}
-	if attrs&tcell.AttrReverse != 0 {
-		parts = append(parts, "Reverse")
-	}
-	if attrs&tcell.AttrDim != 0 {
-		parts = append(parts, "Dim")
-	}
-	if attrs&tcell.AttrItalic != 0 {
-		parts = append(parts, "Italic")
-	}
-	if attrs&tcell.AttrStrikeThrough != 0 {
-		parts = append(parts, "StrikeThrough")
-	}
-	return strings.Join(parts, ", ")
+	return ""
 }
 
 func ustyleString(uStyle tcell.UnderlineStyle) string {
 	switch uStyle {
 	case tcell.UnderlineStyleSolid:
-		return "Underline"
+		return ""
 	case tcell.UnderlineStyleDouble:
-		return "Underline=Double"
+		return "=Double"
 	case tcell.UnderlineStyleCurly:
-		return "Underline=Curly"
+		return "=Curly"
 	case tcell.UnderlineStyleDotted:
-		return "Underline=Dotted"
+		return "=Dotted"
 	case tcell.UnderlineStyleDashed:
-		return "Underline=Dashed"
+		return "=Dashed"
 	default:
-		return "Underline=None"
+		return "=None"
 	}
 }

--- a/oviewer/style_stats.go
+++ b/oviewer/style_stats.go
@@ -1,8 +1,11 @@
 package oviewer
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/gdamore/tcell/v3"
 )
 
 // validateStyle confirms the style input and applies the selection.
@@ -113,4 +116,73 @@ func (m *Document) toggleStyleIdx(idx int) {
 		return
 	}
 	m.styles.Set(k, !v)
+}
+
+func styleString(style tcell.Style) string {
+	fg := style.GetForeground()
+	bg := style.GetBackground()
+	attrs := style.GetAttributes()
+	uStyle := style.GetUnderlineStyle()
+	uColor := style.GetUnderlineColor()
+	defaultFG := tcell.StyleDefault.GetForeground()
+	defaultBG := tcell.StyleDefault.GetBackground()
+	defaultAttrs := tcell.StyleDefault.GetAttributes()
+
+	parts := make([]string, 0, 3)
+	if fg != defaultFG {
+		parts = append(parts, fmt.Sprintf("FG=%v", fg.String()))
+	}
+	if bg != defaultBG {
+		parts = append(parts, fmt.Sprintf("BG=%v", bg.String()))
+	}
+	if attrs != defaultAttrs {
+		parts = append(parts, fmt.Sprintf("%v", attrString(attrs)))
+	}
+	if uStyle != tcell.UnderlineStyleNone {
+		parts = append(parts, fmt.Sprintf("%v", ustyleString(uStyle)))
+	}
+	if uColor != defaultFG {
+		parts = append(parts, fmt.Sprintf("UnderlineColor=%v", uColor.String()))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func attrString(attrs tcell.AttrMask) string {
+	var parts []string
+	if attrs&tcell.AttrBold != 0 {
+		parts = append(parts, "Bold")
+	}
+	if attrs&tcell.AttrBlink != 0 {
+		parts = append(parts, "Blink")
+	}
+	if attrs&tcell.AttrReverse != 0 {
+		parts = append(parts, "Reverse")
+	}
+	if attrs&tcell.AttrDim != 0 {
+		parts = append(parts, "Dim")
+	}
+	if attrs&tcell.AttrItalic != 0 {
+		parts = append(parts, "Italic")
+	}
+	if attrs&tcell.AttrStrikeThrough != 0 {
+		parts = append(parts, "StrikeThrough")
+	}
+	return strings.Join(parts, ", ")
+}
+
+func ustyleString(uStyle tcell.UnderlineStyle) string {
+	switch uStyle {
+	case tcell.UnderlineStyleSolid:
+		return "Underline"
+	case tcell.UnderlineStyleDouble:
+		return "Underline=Double"
+	case tcell.UnderlineStyleCurly:
+		return "Underline=Curly"
+	case tcell.UnderlineStyleDotted:
+		return "Underline=Dotted"
+	case tcell.UnderlineStyleDashed:
+		return "Underline=Dashed"
+	default:
+		return "Underline=None"
+	}
 }

--- a/oviewer/style_stats_test.go
+++ b/oviewer/style_stats_test.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
@@ -200,5 +201,35 @@ func TestProcessingToken(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestStyleStats_FromAnsiSample40Patterns(t *testing.T) {
+	root := rootFileReadHelper(t, filepath.Join(testdata, "ansiescape_style_stats_screen.txt"))
+	m := root.Doc
+
+	for i := 0; i < m.BufEndNum(); i++ {
+		_ = m.getLineC(i)
+	}
+
+	const wantPatterns = 40
+	if got := m.styles.Len(); got != wantPatterns {
+		t.Fatalf("styles.Len()=%d want=%d", got, wantPatterns)
+	}
+
+	seen := make(map[string]struct{}, wantPatterns)
+	for i := 0; i < m.styles.Len(); i++ {
+		style, _, ok := m.styles.Index(i)
+		if !ok {
+			t.Fatalf("styles.Index(%d) not found", i)
+		}
+		s := styleString(style)
+		if s == "" {
+			t.Fatalf("styleString() is empty at index=%d", i)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate styleString=%q", s)
+		}
+		seen[s] = struct{}{}
 	}
 }

--- a/testdata/ansiescape_style_stats_screen.txt
+++ b/testdata/ansiescape_style_stats_screen.txt
@@ -1,0 +1,42 @@
+styleString coverage sample (40 patterns)
+-----------------------------------------
+01 [30mFG black[0m
+02 [31mFG red[0m
+03 [32mFG green[0m
+04 [33mFG yellow[0m
+05 [34mFG blue[0m
+06 [35mFG magenta[0m
+07 [36mFG cyan[0m
+08 [37mFG white[0m
+09 [90mFG bright black[0m
+10 [91mFG bright red[0m
+11 [92mFG bright green[0m
+12 [93mFG bright yellow[0m
+13 [94mFG bright blue[0m
+14 [95mFG bright magenta[0m
+15 [96mFG bright cyan[0m
+16 [97mFG bright white[0m
+17 [40mBG black[0m
+18 [41mBG red[0m
+19 [42mBG green[0m
+20 [43mBG yellow[0m
+21 [44mBG blue[0m
+22 [45mBG magenta[0m
+23 [46mBG cyan[0m
+24 [47mBG white[0m
+25 [1mBold[0m
+26 [2mDim[0m
+27 [3mItalic[0m
+28 [5mBlink[0m
+29 [7mReverse[0m
+30 [9mStrike[0m
+31 [4:1mUnderline solid[0m
+32 [4:2mUnderline double[0m
+33 [4:3mUnderline curly[0m
+34 [4:4mUnderline dotted[0m
+35 [4:5mUnderline dashed[0m
+36 [4:1;58;5;196mUnderline color red[0m
+37 [4:1;58;5;46mUnderline color green[0m
+38 [4:1;58;2;70;130;255mUnderline color 24bit[0m
+39 [1;31;47mBold+FG+BG[0m
+40 [1;4:2;58;5;226;38;5;21mBold+ULdouble+ULcolor+FG256[0m

--- a/testdata/ansiescape_style_stats_screen.txt
+++ b/testdata/ansiescape_style_stats_screen.txt
@@ -1,42 +1,42 @@
 styleString coverage sample (40 patterns)
 -----------------------------------------
-01 [30mFG black[0m
-02 [31mFG red[0m
-03 [32mFG green[0m
-04 [33mFG yellow[0m
-05 [34mFG blue[0m
-06 [35mFG magenta[0m
-07 [36mFG cyan[0m
-08 [37mFG white[0m
-09 [90mFG bright black[0m
-10 [91mFG bright red[0m
-11 [92mFG bright green[0m
-12 [93mFG bright yellow[0m
-13 [94mFG bright blue[0m
-14 [95mFG bright magenta[0m
-15 [96mFG bright cyan[0m
-16 [97mFG bright white[0m
-17 [40mBG black[0m
-18 [41mBG red[0m
-19 [42mBG green[0m
-20 [43mBG yellow[0m
-21 [44mBG blue[0m
-22 [45mBG magenta[0m
-23 [46mBG cyan[0m
-24 [47mBG white[0m
-25 [1mBold[0m
-26 [2mDim[0m
-27 [3mItalic[0m
-28 [5mBlink[0m
-29 [7mReverse[0m
-30 [9mStrike[0m
-31 [4:1mUnderline solid[0m
-32 [4:2mUnderline double[0m
-33 [4:3mUnderline curly[0m
-34 [4:4mUnderline dotted[0m
-35 [4:5mUnderline dashed[0m
-36 [4:1;58;5;196mUnderline color red[0m
-37 [4:1;58;5;46mUnderline color green[0m
-38 [4:1;58;2;70;130;255mUnderline color 24bit[0m
-39 [1;31;47mBold+FG+BG[0m
-40 [1;4:2;58;5;226;38;5;21mBold+ULdouble+ULcolor+FG256[0m
+00 [30mFG black[0m
+01 [31mFG red[0m
+02 [32mFG green[0m
+03 [33mFG yellow[0m
+04 [34mFG blue[0m
+05 [35mFG magenta[0m
+06 [36mFG cyan[0m
+07 [37mFG white[0m
+08 [90mFG bright black[0m
+09 [91mFG bright red[0m
+10 [92mFG bright green[0m
+11 [93mFG bright yellow[0m
+12 [94mFG bright blue[0m
+13 [95mFG bright magenta[0m
+14 [96mFG bright cyan[0m
+15 [97mFG bright white[0m
+16 [40mBG black[0m
+17 [41mBG red[0m
+18 [42mBG green[0m
+19 [43mBG yellow[0m
+20 [44mBG blue[0m
+21 [45mBG magenta[0m
+22 [46mBG cyan[0m
+23 [47mBG white[0m
+24 [1mBold[0m
+25 [2mDim[0m
+26 [3mItalic[0m
+27 [5mBlink[0m
+28 [7mReverse[0m
+29 [9mStrike[0m
+30 [4:1mUnderline solid[0m
+31 [4:2mUnderline double[0m
+32 [4:3mUnderline curly[0m
+33 [4:4mUnderline dotted[0m
+34 [4:5mUnderline dashed[0m
+35 [4:1;58;5;196mUnderline color red[0m
+36 [4:1;58;5;46mUnderline color green[0m
+37 [4:1;58;2;70;130;255mUnderline color 24bit[0m
+38 [1;31;47mBold+FG+BG[0m
+39 [1;4:2;58;5;226;38;5;21mBold+ULdouble+ULcolor+FG256[0m


### PR DESCRIPTION
- move styleString from sidebar logic to style stats module
- improve styleString output to include readable attributes, underline style, and underline color
- update style sidebar help text for clearer command guidance
- add ANSI sample fixture covering 40 style patterns
- add test to verify style extraction count and styleString uniqueness