### PR TITLE
Add Emacs-like keybindings as a preset configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,6 +150,8 @@ func renderConfigTemplate(mode string) (string, error) {
 		keyBind = oviewer.DefaultKeyBinds()
 	case "less":
 		keyBind = oviewer.LessKeyBinds()
+	case "emacs":
+		keyBind = oviewer.EmacsKeyBinds()
 	default:
 		return "", fmt.Errorf("unsupported: %q; %s", mode, ErrGenerateConfigArg)
 	}
@@ -458,10 +460,10 @@ func init() {
 	_ = rootCmd.RegisterFlagCompletionFunc("completion", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"bash", "zsh", "fish", "powershell"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	rootCmd.PersistentFlags().StringVar(&generateConfig, "generate-config", "", "print a sample config file to stdout [default|less]")
+	rootCmd.PersistentFlags().StringVar(&generateConfig, "generate-config", "", "print a sample config file to stdout [default|less|emacs]")
 	rootCmd.PersistentFlags().Lookup("generate-config").NoOptDefVal = "default"
 	_ = rootCmd.RegisterFlagCompletionFunc("generate-config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"default", "less"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"default", "less", "emacs"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	rootCmd.PersistentFlags().StringVarP(&pattern, "pattern", "", "", "initial search pattern applied on startup")

--- a/oviewer/help_test.go
+++ b/oviewer/help_test.go
@@ -42,6 +42,11 @@ func TestDuplicateKeyBind(t *testing.T) {
 			k:    LessKeyBinds(),
 			want: "",
 		},
+		{
+			name: "EmacsKeyBind",
+			k:    EmacsKeyBinds(),
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -543,6 +543,8 @@ func GetKeyBinds(config Config) KeyBind {
 		// no default keybindings
 	case "less":
 		keyBind = LessKeyBinds()
+	case "emacs":
+		keyBind = EmacsKeyBinds()
 	default:
 		keyBind = DefaultKeyBinds()
 	}

--- a/oviewer/keydefine.go
+++ b/oviewer/keydefine.go
@@ -167,3 +167,30 @@ func LessKeyBinds() KeyBind {
 
 	return keyBind
 }
+
+// EmacsKeyBinds are keybindings preset for Emacs-like operations.
+func EmacsKeyBinds() KeyBind {
+	keyBind := DefaultKeyBinds()
+
+	maps.Copy(keyBind, KeyBind{
+		actionCancel:    {"ctrl+c", "ctrl+g"},
+		actionEdit:      {"v"},
+		actionFollow:    {"alt+ctrl+f"},
+		actionFollowAll: {"alt+ctrl+a"},
+
+		// Move actions.
+		actionMoveLeft:    {"left", "ctrl+b"},
+		actionMoveRight:   {"right", "ctrl+f"},
+		actionMovePgUp:    {"PageUp", "alt+v"},
+		actionMovePgDn:    {"PageDown", "ctrl+v", "space"},
+		actionMoveTop:     {"Home", "alt+shift+,"}, // '>' with Alt must be written as 'shift+,'.
+		actionMoveBottom:  {"End", "alt+shift+."},  // '<' with Alt must be written as 'shift+.'.
+		actionNextSection: {"ctrl+F6"},
+
+		// Actions that enter input mode.
+		actionSearch:    {"/", "ctrl+s"},
+		actionSkipLines: {"ctrl+F5"},
+	})
+
+	return keyBind
+}

--- a/oviewer/keydefine.go
+++ b/oviewer/keydefine.go
@@ -183,8 +183,8 @@ func EmacsKeyBinds() KeyBind {
 		actionMoveRight:   {"right", "ctrl+f"},
 		actionMovePgUp:    {"PageUp", "alt+v"},
 		actionMovePgDn:    {"PageDown", "ctrl+v", "space"},
-		actionMoveTop:     {"Home", "alt+shift+,"}, // '>' with Alt must be written as 'shift+,'.
-		actionMoveBottom:  {"End", "alt+shift+."},  // '<' with Alt must be written as 'shift+.'.
+		actionMoveTop:     {"Home", "alt+shift+,", "alt+<"},
+		actionMoveBottom:  {"End", "alt+shift+.", "alt+>"},
 		actionNextSection: {"ctrl+F6"},
 
 		// Actions that enter input mode.


### PR DESCRIPTION
- Add EmacsKeyBinds function that returns a KeyBind with Emacs-like keybindings.
- Update GetKeyBinds to include the "emacs" preset.
- Update renderConfigTemplate to include the "emacs" preset.
- Update the help test to include a test case for EmacsKeyBinds.