### PR TITLE
Add native Wayland clipboard support via wl-copy/wl-paste (#834)

### DIFF
--- a/oviewer/clipboard_wayland.go
+++ b/oviewer/clipboard_wayland.go
@@ -1,0 +1,44 @@
+package oviewer
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// waylandClipboardAvailable reports whether the Wayland clipboard can be used,
+// i.e. the session is Wayland and wl-clipboard (wl-copy/wl-paste) is installed.
+// golang.design/x/clipboard only reaches the clipboard via XWayland, so on a
+// Wayland session without XWayland it silently fails; wl-clipboard talks to
+// the compositor directly.
+func waylandClipboardAvailable() bool {
+	if os.Getenv("WAYLAND_DISPLAY") == "" {
+		return false
+	}
+	if _, err := exec.LookPath("wl-copy"); err != nil {
+		return false
+	}
+	if _, err := exec.LookPath("wl-paste"); err != nil {
+		return false
+	}
+	return true
+}
+
+// writeWaylandClipboard writes str to the Wayland clipboard via wl-copy.
+func writeWaylandClipboard(str string) error {
+	c := exec.Command("wl-copy")
+	c.Stdin = strings.NewReader(str)
+	return c.Run()
+}
+
+// readWaylandClipboard reads the Wayland clipboard via wl-paste.
+func readWaylandClipboard() (string, error) {
+	c := exec.Command("wl-paste", "-n")
+	var out bytes.Buffer
+	c.Stdout = &out
+	if err := c.Run(); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}

--- a/oviewer/clipboard_wayland.go
+++ b/oviewer/clipboard_wayland.go
@@ -2,17 +2,38 @@ package oviewer
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
+	"time"
+)
+
+// waylandClipboardTimeout bounds wl-copy/wl-paste so a frozen compositor or a
+// stale WAYLAND_DISPLAY (e.g. left over after a session restart) can't hang
+// the single UI event-loop goroutine that calls these.
+const waylandClipboardTimeout = 2 * time.Second
+
+var (
+	waylandAvailableOnce sync.Once
+	waylandAvailableVal  bool
 )
 
 // waylandClipboardAvailable reports whether the Wayland clipboard can be used,
 // i.e. the session is Wayland and wl-clipboard (wl-copy/wl-paste) is installed.
 // golang.design/x/clipboard only reaches the clipboard via XWayland, so on a
 // Wayland session without XWayland it silently fails; wl-clipboard talks to
-// the compositor directly.
+// the compositor directly. The result is cached: it can't change for the
+// life of the process.
 func waylandClipboardAvailable() bool {
+	waylandAvailableOnce.Do(func() {
+		waylandAvailableVal = checkWaylandClipboardAvailable()
+	})
+	return waylandAvailableVal
+}
+
+func checkWaylandClipboardAvailable() bool {
 	if os.Getenv("WAYLAND_DISPLAY") == "" {
 		return false
 	}
@@ -25,16 +46,20 @@ func waylandClipboardAvailable() bool {
 	return true
 }
 
-// writeWaylandClipboard writes str to the Wayland clipboard via wl-copy.
 func writeWaylandClipboard(str string) error {
-	c := exec.Command("wl-copy")
+	ctx, cancel := context.WithTimeout(context.Background(), waylandClipboardTimeout)
+	defer cancel()
+
+	c := exec.CommandContext(ctx, "wl-copy")
 	c.Stdin = strings.NewReader(str)
 	return c.Run()
 }
 
-// readWaylandClipboard reads the Wayland clipboard via wl-paste.
 func readWaylandClipboard() (string, error) {
-	c := exec.Command("wl-paste", "-n")
+	ctx, cancel := context.WithTimeout(context.Background(), waylandClipboardTimeout)
+	defer cancel()
+
+	c := exec.CommandContext(ctx, "wl-paste", "-n")
 	var out bytes.Buffer
 	c.Stdout = &out
 	if err := c.Run(); err != nil {

--- a/oviewer/clipboard_wayland_test.go
+++ b/oviewer/clipboard_wayland_test.go
@@ -5,6 +5,7 @@ package oviewer
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -31,28 +32,49 @@ func withFakeWaylandTools(t *testing.T) {
 	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
 }
 
-func Test_waylandClipboardAvailable(t *testing.T) {
+// checkWaylandClipboardAvailable holds the actual detection logic;
+// waylandClipboardAvailable just memoizes it for the process lifetime, which
+// would make these env/PATH-toggling subtests order-dependent if they called
+// the memoized wrapper instead.
+func Test_checkWaylandClipboardAvailable(t *testing.T) {
 	t.Run("no WAYLAND_DISPLAY", func(t *testing.T) {
 		t.Setenv("WAYLAND_DISPLAY", "")
-		if waylandClipboardAvailable() {
-			t.Error("waylandClipboardAvailable() = true, want false without WAYLAND_DISPLAY")
+		if checkWaylandClipboardAvailable() {
+			t.Error("checkWaylandClipboardAvailable() = true, want false without WAYLAND_DISPLAY")
 		}
 	})
 
 	t.Run("WAYLAND_DISPLAY set but wl-clipboard missing", func(t *testing.T) {
 		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
 		t.Setenv("PATH", t.TempDir())
-		if waylandClipboardAvailable() {
-			t.Error("waylandClipboardAvailable() = true, want false without wl-copy/wl-paste in PATH")
+		if checkWaylandClipboardAvailable() {
+			t.Error("checkWaylandClipboardAvailable() = true, want false without wl-copy/wl-paste in PATH")
 		}
 	})
 
 	t.Run("WAYLAND_DISPLAY set and wl-clipboard installed", func(t *testing.T) {
 		withFakeWaylandTools(t)
-		if !waylandClipboardAvailable() {
-			t.Error("waylandClipboardAvailable() = false, want true with WAYLAND_DISPLAY and wl-copy/wl-paste in PATH")
+		if !checkWaylandClipboardAvailable() {
+			t.Error("checkWaylandClipboardAvailable() = false, want true with WAYLAND_DISPLAY and wl-copy/wl-paste in PATH")
 		}
 	})
+}
+
+func Test_waylandClipboardAvailable_caches(t *testing.T) {
+	withFakeWaylandTools(t)
+	waylandAvailableOnce = sync.Once{}
+	t.Cleanup(func() { waylandAvailableOnce = sync.Once{} })
+
+	if !waylandClipboardAvailable() {
+		t.Fatal("waylandClipboardAvailable() = false, want true with WAYLAND_DISPLAY and wl-copy/wl-paste in PATH")
+	}
+
+	// Even after the environment no longer satisfies checkWaylandClipboardAvailable,
+	// the memoized result from the first call should stick for the process lifetime.
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if !waylandClipboardAvailable() {
+		t.Error("waylandClipboardAvailable() = false, want cached true despite WAYLAND_DISPLAY being unset afterward")
+	}
 }
 
 func Test_waylandClipboard_writeRead(t *testing.T) {

--- a/oviewer/clipboard_wayland_test.go
+++ b/oviewer/clipboard_wayland_test.go
@@ -1,0 +1,73 @@
+//go:build !windows
+
+package oviewer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withFakeWaylandTools creates fake wl-copy/wl-paste executables backed by a
+// temp file, prepends their directory to PATH, and restores both on cleanup.
+func withFakeWaylandTools(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	clipFile := filepath.Join(dir, "clip.txt")
+
+	scripts := map[string]string{
+		"wl-copy":  "#!/bin/sh\ncat > \"" + clipFile + "\"\n",
+		"wl-paste": "#!/bin/sh\ncat \"" + clipFile + "\"\n",
+	}
+	for name, content := range scripts {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+			t.Fatalf("failed to write fake %s: %v", name, err)
+		}
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+}
+
+func Test_waylandClipboardAvailable(t *testing.T) {
+	t.Run("no WAYLAND_DISPLAY", func(t *testing.T) {
+		t.Setenv("WAYLAND_DISPLAY", "")
+		if waylandClipboardAvailable() {
+			t.Error("waylandClipboardAvailable() = true, want false without WAYLAND_DISPLAY")
+		}
+	})
+
+	t.Run("WAYLAND_DISPLAY set but wl-clipboard missing", func(t *testing.T) {
+		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+		t.Setenv("PATH", t.TempDir())
+		if waylandClipboardAvailable() {
+			t.Error("waylandClipboardAvailable() = true, want false without wl-copy/wl-paste in PATH")
+		}
+	})
+
+	t.Run("WAYLAND_DISPLAY set and wl-clipboard installed", func(t *testing.T) {
+		withFakeWaylandTools(t)
+		if !waylandClipboardAvailable() {
+			t.Error("waylandClipboardAvailable() = false, want true with WAYLAND_DISPLAY and wl-copy/wl-paste in PATH")
+		}
+	})
+}
+
+func Test_waylandClipboard_writeRead(t *testing.T) {
+	withFakeWaylandTools(t)
+
+	want := "ov wayland clipboard test"
+	if err := writeWaylandClipboard(want); err != nil {
+		t.Fatalf("writeWaylandClipboard() error = %v", err)
+	}
+
+	got, err := readWaylandClipboard()
+	if err != nil {
+		t.Fatalf("readWaylandClipboard() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("readWaylandClipboard() = %q, want %q", got, want)
+	}
+}

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -546,17 +546,19 @@ func (root *Root) copyClipboard(str string) {
 	case "OSC52":
 		root.Screen.SetClipboard([]byte(str))
 	default:
-		writeSystemClipboard(str)
+		root.writeSystemClipboard(str)
 	}
 }
 
 // writeSystemClipboard writes str to the system clipboard, preferring the
 // Wayland clipboard when available (see waylandClipboardAvailable).
-func writeSystemClipboard(str string) {
+func (root *Root) writeSystemClipboard(str string) {
 	if waylandClipboardAvailable() {
-		if err := writeWaylandClipboard(str); err == nil {
+		err := writeWaylandClipboard(str)
+		if err == nil {
 			return
 		}
+		root.debugMessage("writeSystemClipboard: wl-copy failed: " + err.Error())
 	}
 	clipboard.Write(clipboard.FmtText, []byte(str))
 }
@@ -583,7 +585,7 @@ func (root *Root) pasteFromClipboard(context.Context) {
 		return
 	}
 
-	str := readSystemClipboard()
+	str := root.readSystemClipboard()
 	left, right := splitAtWidth(input.value, input.cursorX)
 	input.value = left + str + right
 	input.cursorX += stringWidth(str)
@@ -591,11 +593,13 @@ func (root *Root) pasteFromClipboard(context.Context) {
 
 // readSystemClipboard reads from the system clipboard, preferring the
 // Wayland clipboard when available (see waylandClipboardAvailable).
-func readSystemClipboard() string {
+func (root *Root) readSystemClipboard() string {
 	if waylandClipboardAvailable() {
-		if str, err := readWaylandClipboard(); err == nil {
+		str, err := readWaylandClipboard()
+		if err == nil {
 			return str
 		}
+		root.debugMessage("readSystemClipboard: wl-paste failed: " + err.Error())
 	}
 	return string(clipboard.Read(clipboard.FmtText))
 }

--- a/oviewer/mouse.go
+++ b/oviewer/mouse.go
@@ -545,11 +545,20 @@ func (root *Root) copyClipboard(str string) {
 	switch root.Config.ClipboardMethod {
 	case "OSC52":
 		root.Screen.SetClipboard([]byte(str))
-	case "system":
-		clipboard.Write(clipboard.FmtText, []byte(str))
 	default:
-		clipboard.Write(clipboard.FmtText, []byte(str))
+		writeSystemClipboard(str)
 	}
+}
+
+// writeSystemClipboard writes str to the system clipboard, preferring the
+// Wayland clipboard when available (see waylandClipboardAvailable).
+func writeSystemClipboard(str string) {
+	if waylandClipboardAvailable() {
+		if err := writeWaylandClipboard(str); err == nil {
+			return
+		}
+	}
+	clipboard.Write(clipboard.FmtText, []byte(str))
 }
 
 type eventPaste struct {
@@ -574,11 +583,21 @@ func (root *Root) pasteFromClipboard(context.Context) {
 		return
 	}
 
-	buf := clipboard.Read(clipboard.FmtText)
-	str := string(buf)
+	str := readSystemClipboard()
 	left, right := splitAtWidth(input.value, input.cursorX)
 	input.value = left + str + right
 	input.cursorX += stringWidth(str)
+}
+
+// readSystemClipboard reads from the system clipboard, preferring the
+// Wayland clipboard when available (see waylandClipboardAvailable).
+func readSystemClipboard() string {
+	if waylandClipboardAvailable() {
+		if str, err := readWaylandClipboard(); err == nil {
+			return str
+		}
+	}
+	return string(clipboard.Read(clipboard.FmtText))
 }
 
 func (root *Root) rangeToString(startX, startY, endX, endY int) (string, error) {


### PR DESCRIPTION
Closes #834.

In that issue, you suggested calling wl-copy/wl-paste directly when running under Wayland, since `golang.design/x/clipboard` only works through XWayland. This PR does that.

What it does:
- When `WAYLAND_DISPLAY` is set and `wl-copy`/`wl-paste` are installed, copy and paste use them.
- Otherwise, behavior is unchanged — same fallback to `golang.design/x/clipboard` as before.
- If `wl-copy`/`wl-paste` fail at runtime, it falls back too, and logs the error in debug mode.
- The Wayland check only runs once per session (cached), so it doesn't slow down every copy/paste.
- The subprocess calls have a 2-second timeout, so a frozen compositor can't freeze ov.

One thing I wasn't sure about: right now this is just part of the existing `"system"` `ClipboardMethod`, picked automatically. If you'd prefer it as its own named option (e.g. `"wayland"`) so users can choose explicitly, I'm happy to change it — just let me know which you'd like, or if the automatic choice is fine.

Tested on a real Wayland session (copy and paste both work). Also added unit tests for the new code, and confirmed `go build`, `go vet`, and `go test ./...` all pass.