### PR TITLE
fix(sidebar): apply current item style independently of base item style

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -635,17 +635,16 @@ func (root *Root) drawSidebarList(items []SidebarItem) {
 
 	sidebarStyle := defaultStyle
 	root.Screen.PutStrStyled(3, 0, root.sidebarMode.String(), sidebarStyle.Bold(true))
-	currentStyle := defaultStyle.Bold(true).Reverse(true)
+	currentStyle := OVStyle{Bold: true, Reverse: true}
 
 	height := root.scr.vHeight
 	maxList := min(len(items), height-2)
 	for i := range maxList {
 		item := items[i]
-		style := sidebarStyle
+		root.drawSidebarItem(scroll.x, i+1, item, sidebarStyle)
 		if item.IsCurrent {
-			style = currentStyle
+			root.applyStyleToRange(i+1, currentStyle, 0, root.sidebarWidth-1)
 		}
-		root.drawSidebarItem(scroll.x, i+1, item, style)
 	}
 }
 


### PR DESCRIPTION
Ensure the current sidebar item styling is applied regardless of the item's original style by drawing the item first and then overlaying the current style range.