### PR TITLE
Refactor OVStyle application in drawing paths

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -419,8 +419,8 @@ func (root *Root) applyStyleToAlternate(lN int, y int) {
 
 // applyStyleToLine applies the style from the left edge to the right edge of the physical line.
 // Apply styles to the screen.
-func (root *Root) applyStyleToLine(y int, s OVStyle) {
-	root.applyStyleToRange(y, s, root.Doc.bodyStartX, root.Doc.bodyStartX+root.Doc.width)
+func (root *Root) applyStyleToLine(y int, ovs OVStyle) {
+	root.applyStyleToRange(y, ovs, root.Doc.bodyStartX, root.Doc.bodyStartX+root.Doc.width)
 }
 
 // applyMarkStyle applies the style from the left edge to the specified width.
@@ -433,10 +433,10 @@ func (root *Root) applyMarkStyle(lN int, y int, width int) {
 }
 
 // applyStyleToRange applies the style from the start to the end of the physical line.
-func (root *Root) applyStyleToRange(y int, s OVStyle, start int, end int) {
+func (root *Root) applyStyleToRange(y int, ovs OVStyle, start int, end int) {
 	for x := start; x < end; x++ {
 		str, style, width := root.Screen.Get(x, y)
-		newStyle := applyStyle(style, s)
+		newStyle := applyStyle(style, ovs)
 		if style != newStyle {
 			root.Screen.Put(x, y, str, newStyle)
 		}
@@ -564,13 +564,10 @@ func (root *Root) flash() {
 
 // putContents puts the contents on the screen at the specified position with the given style.
 // If the content has its own style, it will be used instead of the provided style.
-func (root *Root) putContents(x int, y int, contents contents, style tcell.Style) {
+func (root *Root) putContents(x int, y int, contents contents, ovs OVStyle) {
 	for i, c := range contents {
-		if c.style != defaultStyle {
-			root.put(x+i, y, c.str, c.style)
-		} else {
-			root.put(x+i, y, c.str, style)
-		}
+		style := applyStyle(c.style, ovs)
+		root.put(x+i, y, c.str, style)
 	}
 }
 
@@ -653,7 +650,7 @@ func (root *Root) drawSidebarList(items []SidebarItem) {
 	maxList := min(len(items), height-2)
 	for i := range maxList {
 		item := items[i]
-		root.drawSidebarItem(scroll.x, i+1, item, sidebarStyle)
+		root.drawSidebarItem(scroll.x, i+1, item, OVStyle{})
 		if item.IsCurrent {
 			root.applyStyleToRange(i+1, currentStyle, 0, root.sidebarWidth-1)
 		}
@@ -661,18 +658,18 @@ func (root *Root) drawSidebarList(items []SidebarItem) {
 }
 
 // drawSidebarItem draws a single SidebarItem in the sidebar with the specified style and scroll position.
-func (root *Root) drawSidebarItem(x int, y int, item SidebarItem, style tcell.Style) {
+func (root *Root) drawSidebarItem(x int, y int, item SidebarItem, ovs OVStyle) {
 	label := StrToContents(item.Label, -1)
 	labelLen := len(label)
 	if labelLen > root.sidebarWidth-2 {
 		label = label[:root.sidebarWidth-2]
 	}
-	root.putContents(0, y, label, style)
+	root.putContents(0, y, label, ovs)
 
 	left := min(x, len(item.Contents))
 	width := max(min(root.sidebarWidth-(len(label)+2), len(item.Contents)-left), 0)
 	right := min(left+width, len(item.Contents))
-	root.putContents(len(label), y, item.Contents[left:right], style)
+	root.putContents(len(label), y, item.Contents[left:right], ovs)
 }
 
 // sidebarScroll returns the current scroll position of the sidebar and updates it if necessary.

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -711,8 +711,8 @@ func alignColumnEnd(lc contents, widths []int, n int, start int) int {
 
 // RangeStyle applies the style to the specified range.
 // Apply style to contents.
-func RangeStyle(lc contents, start int, end int, s OVStyle) {
+func RangeStyle(lc contents, start int, end int, ovs OVStyle) {
 	for x := start; x < end; x++ {
-		lc[x].style = applyStyle(lc[x].style, s)
+		lc[x].style = applyStyle(lc[x].style, ovs)
 	}
 }

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -47,14 +47,18 @@ func (root *Root) normalLeftStatus() int {
 			sColor = color.Color((root.CurrentDoc + 8) % 16)
 		}
 	}
+	sColorName := (color.IsValid + sColor).String()
+	s := root.Doc.Style.LeftStatus
+	if root.Doc.Normal.InvertColor {
+		s = OVStyle{
+			Foreground: sColorName,
+			Reverse:    true,
+		}
+	}
 
 	str := root.StrLeftStatus(numVisible)
-	style := applyStyle(tcell.StyleDefault, root.Doc.Style.LeftStatus)
-	if root.Doc.Normal.InvertColor {
-		style = style.Foreground(color.IsValid + sColor).Reverse(true)
-	}
 	contents := StrToContents(str, -1)
-	root.putContents(0, root.Doc.statusPos, contents, style)
+	root.putContents(0, root.Doc.statusPos, contents, s)
 
 	cursorColor := color.GetColor(root.Doc.Style.LeftStatus.Foreground)
 	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Normal.CursorType), cursorColor)
@@ -107,9 +111,8 @@ func (root *Root) inputLeftStatus() int {
 	input := root.input
 	prompt := root.inputPrompt()
 
-	style := applyStyle(tcell.StyleDefault, root.Doc.Style.LeftStatus)
 	contents := StrToContents(prompt+input.value, -1)
-	root.putContents(0, root.Doc.statusPos, contents, style)
+	root.putContents(0, root.Doc.statusPos, contents, root.Doc.Style.LeftStatus)
 	cursorColor := color.GetColor(root.Doc.Style.LeftStatus.Foreground)
 	root.Screen.SetCursorStyle(tcell.CursorStyle(root.Doc.Input.CursorType), cursorColor)
 


### PR DESCRIPTION
Use OVStyle consistently in line, range, and content drawing helpers.
This keeps style composition centralized and fixes status/sidebar rendering to apply document styles through the same path.