### PR TITLE
Add a debug message to show the keyboard protocol

### DIFF
--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -592,6 +592,7 @@ func (root *Root) Run() error {
 	if err := root.switchToRealScreen(); err != nil {
 		return err
 	}
+	root.debugMessage("Keyboard protocol: " + keyProtocolName(root.Screen.KeyboardProtocol()))
 
 	if !root.Config.DisableMouse {
 		root.Screen.EnableMouse(MouseFlags)
@@ -782,6 +783,19 @@ func (root *Root) debugMessage(msg string) {
 		return
 	}
 	log.Printf("%s:%s\n", root.Doc.FileName, msg)
+}
+
+func keyProtocolName(p tcell.KeyProtocol) string {
+	switch p {
+	case tcell.KittyKeyboard:
+		return "kitty"
+	case tcell.Win32Keyboard:
+		return "win32"
+	case tcell.XTermKeyboard:
+		return "xterm"
+	default:
+		return "legacy"
+	}
 }
 
 // docSmall returns with bool whether the file to display fits on the screen.


### PR DESCRIPTION
Add a debug message to show the keyboard protocol used by tcell when switching to the real screen. This helps in identifying which keyboard protocol is being utilized during the execution of the program, especially useful for debugging and ensuring compatibility with different terminal emulators.