### PR TITLE
sidebar: show message when no ANSI escape sequences are found

### DIFF
--- a/oviewer/sidebar.go
+++ b/oviewer/sidebar.go
@@ -249,12 +249,18 @@ func (root *Root) sidebarItemsForStyles() []SidebarItem {
 	var items []SidebarItem
 	length := root.sidebarWidth - 4
 	root.Doc.EnsureStylesLoaded()
+	stylesLen := root.Doc.styles.Len()
 	helpLines := []string{
 		"o: disable all, then enable (e.g., o1)",
 		"a: enable all (e.g., a1-2)",
 		"i: invert all (e.g., i1,3)",
 	}
-	totalLines := root.Doc.styles.Len() + len(helpLines)
+	if stylesLen == 0 {
+		helpLines = []string{
+			"No ANSI escape sequences found.",
+		}
+	}
+	totalLines := stylesLen + len(helpLines)
 	root.adjustSidebarScroll(SidebarModeStyles, totalLines, 0)
 	scroll := root.sidebarScrolls[SidebarModeStyles]
 	start := scroll.y

--- a/oviewer/sidebar_test.go
+++ b/oviewer/sidebar_test.go
@@ -242,6 +242,28 @@ func TestRoot_sidebarItemsForHelp(t *testing.T) {
 	}
 }
 
+func TestRoot_sidebarItemsForStyles_NoANSIStyles(t *testing.T) {
+	root := rootHelper(t)
+	root.scr.vHeight = 20
+	root.sidebarWidth = 30
+	root.sidebarMode = SidebarModeStyles
+
+	items := root.sidebarItemsForStyles()
+	if len(items) != 1 {
+		t.Fatalf("sidebarItemsForStyles() items = %d, want %d", len(items), 1)
+	}
+
+	want := []string{
+		"No ANSI escape sequences found.",
+	}
+	for i, item := range items {
+		got := strings.TrimRight(item.Contents.String(), " ")
+		if got != want[i] {
+			t.Errorf("sidebarItemsForStyles()[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
 func TestRoot_sidebarItemsForSections(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Display a clear notice in the Styles sidebar when no ANSI styles exist, instead of showing style operation hints.
Also add a test case to verify the no-style behavior.