### PR TITLE
Fix race conditions in follow-state handling

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -103,13 +103,13 @@ func (root *Root) toggleRainbow(context.Context) {
 
 // toggleFollowMode toggles follow mode.
 func (root *Root) toggleFollowMode(context.Context) {
-	root.Doc.FollowMode = !root.Doc.FollowMode
+	root.Doc.setFollowMode(!root.Doc.followModeEnabled())
 	root.Doc.pauseFollow = false
 }
 
 // toggleFollowAll toggles follow all mode.
 func (root *Root) toggleFollowAll(context.Context) {
-	root.FollowAll = !root.FollowAll
+	root.setFollowAll(!root.followAllEnabled())
 	root.Doc.pauseFollow = false
 	root.mu.Lock()
 	for _, doc := range root.DocList {
@@ -121,7 +121,7 @@ func (root *Root) toggleFollowAll(context.Context) {
 // toggleFollowSection toggles follow section mode.
 func (root *Root) toggleFollowSection(context.Context) {
 	root.Doc.pauseFollow = false
-	root.Doc.FollowSection = !root.Doc.FollowSection
+	root.Doc.setFollowSection(!root.Doc.followSectionEnabled())
 }
 
 // toggleHideOtherSection toggles hide other section mode.
@@ -891,8 +891,8 @@ func (root *Root) followSection(ctx context.Context) {
 
 // Cancel follow mode and follow all mode.
 func (root *Root) Cancel(context.Context) {
-	root.FollowAll = false
-	root.Doc.FollowMode = false
+	root.setFollowAll(false)
+	root.Doc.setFollowMode(false)
 }
 
 // toggleWriteOriginal toggles the write flag.
@@ -1035,7 +1035,7 @@ func (root *Root) setPauseFollow() {
 	if root.Doc.pauseFollow {
 		return
 	}
-	if root.FollowAll || root.Doc.FollowMode || root.Doc.FollowSection {
+	if root.followAllEnabled() || root.Doc.followModeEnabled() || root.Doc.followSectionEnabled() {
 		root.Doc.pauseFollow = true
 		root.Doc.pauseLastNum = max(root.Doc.BufEndNum()-1, 0)
 	}

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1312,7 +1312,7 @@ func TestRoot_followAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootFileReadHelper(t, tt.args.fileNames...)
-			root.FollowAll = true
+			root.setFollowAll(true)
 			root.Doc.WrapMode = tt.fields.wrapMode
 			ctx := context.Background()
 			root.prepareScreen()

--- a/oviewer/control.go
+++ b/oviewer/control.go
@@ -37,6 +37,7 @@ const (
 func (m *Document) ControlFile(file *os.File) error {
 	m.memoryLimit = loadChunksCapacity(m.seekable)
 	m.store.setNewLoadChunks(m.memoryLimit)
+	m.syncRuntimeFollowStates()
 	atomic.StoreInt32(&m.closed, 0)
 	r, err := m.fileReader(file)
 	if err != nil {
@@ -131,7 +132,7 @@ func (m *Document) controlFile(sc controlSpecifier, reader *bufio.Reader) (*bufi
 		if !m.store.isContinueRead(m.memoryLimit) {
 			return reader, nil
 		}
-		if m.seekable && atomic.LoadInt32(&m.tmpFollow) == 0 && (m.FollowMode || m.FollowAll) {
+		if m.seekable && atomic.LoadInt32(&m.tmpFollow) == 0 && (m.followModeEnabled() || m.followAllEnabled()) {
 			go func() {
 				m.requestBottom()
 			}()

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -103,6 +103,12 @@ type Document struct {
 	allMatchedLinesRunning atomic.Bool
 	// stylesScanRunning guards concurrent style scanning execution.
 	stylesScanRunning atomic.Bool
+	// followModeState is the runtime follow-mode flag used across goroutines.
+	followModeState atomic.Bool
+	// followAllState is the runtime follow-all flag used across goroutines.
+	followAllState atomic.Bool
+	// followSectionState is the runtime follow-section flag used across goroutines.
+	followSectionState atomic.Bool
 
 	// marked is a list of marked line numbers.
 	marked MatchedLineList
@@ -679,6 +685,46 @@ func (m *Document) firstLine() int {
 	return m.SkipLines + m.Header
 }
 
+// syncRuntimeFollowStates synchronizes the runtime follow states with the document's follow settings.
+func (m *Document) syncRuntimeFollowStates() {
+	m.followModeState.Store(m.FollowMode)
+	m.followAllState.Store(m.FollowAll)
+	m.followSectionState.Store(m.FollowSection)
+}
+
+// followModeEnabled returns true if follow mode is enabled.
+func (m *Document) followModeEnabled() bool {
+	return m.followModeState.Load()
+}
+
+// setFollowMode sets the follow mode state and updates the runtime follow-mode flag.
+func (m *Document) setFollowMode(enabled bool) {
+	m.FollowMode = enabled
+	m.followModeState.Store(enabled)
+}
+
+// followAllEnabled returns true if follow-all mode is enabled.
+func (m *Document) followAllEnabled() bool {
+	return m.followAllState.Load()
+}
+
+// setFollowAll sets the follow-all mode state and updates the runtime follow-all flag.
+func (m *Document) setFollowAll(enabled bool) {
+	m.FollowAll = enabled
+	m.followAllState.Store(enabled)
+}
+
+// followSectionEnabled returns true if follow-section mode is enabled.
+func (m *Document) followSectionEnabled() bool {
+	return m.followSectionState.Load()
+}
+
+// setFollowSection sets the follow-section mode state and updates the runtime follow-section flag.
+func (m *Document) setFollowSection(enabled bool) {
+	m.FollowSection = enabled
+	m.followSectionState.Store(enabled)
+}
+
 // watchMode sets the document to watch mode and configures section settings.
 func (m *Document) watchMode() {
 	m.WatchMode = true
@@ -687,13 +733,13 @@ func (m *Document) watchMode() {
 	}
 	m.SectionHeader = false
 	m.SectionStartPosition = 1
-	m.FollowSection = true
+	m.setFollowSection(true)
 }
 
 // unwatchMode disables watch mode for the document.
 func (m *Document) unwatchMode() {
 	m.WatchMode = false
-	m.FollowSection = false
+	m.setFollowSection(false)
 }
 
 // regexpCompile compiles the new document's regular expressions.

--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -206,11 +206,11 @@ func (root *Root) everyUpdate(ctx context.Context) {
 	}
 
 	switch {
-	case root.FollowAll:
+	case root.followAllEnabled():
 		root.followAll(ctx)
-	case root.Doc.FollowMode:
+	case root.Doc.followModeEnabled():
 		root.follow(ctx)
-	case root.Doc.FollowSection:
+	case root.Doc.followSectionEnabled():
 		root.followSection(ctx)
 	}
 

--- a/oviewer/logdoc.go
+++ b/oviewer/logdoc.go
@@ -19,7 +19,7 @@ func NewLogDoc() (*LogDocument, error) {
 		return nil, err
 	}
 	m.documentType = DocLog
-	m.FollowMode = true
+	m.setFollowMode(true)
 	m.Caption = "Log"
 	m.seekable = false
 	m.Style = NewLogStyle()

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -92,6 +92,8 @@ type Root struct {
 	mu sync.RWMutex
 	// isClosed indicates whether it is closed.
 	isClosed atomic.Bool
+	// followAllState is the runtime follow-all flag used across goroutines.
+	followAllState atomic.Bool
 
 	// FollowAll is a follow mode for all documents.
 	FollowAll bool
@@ -466,7 +468,7 @@ func (root *Root) SetConfig(config Config) {
 	}
 
 	// Set the follow mode for all documents.
-	root.FollowAll = root.settings.FollowAll
+	root.setFollowAll(root.settings.FollowAll)
 	// Set the minimum start position of x.
 	root.minStartX = config.MinStartX
 	// Set the caption from the environment variable.
@@ -484,6 +486,32 @@ func (root *Root) SetConfig(config Config) {
 		root.settings.SectionHeader = true
 	}
 	root.Config = config
+}
+
+// followAllEnabled returns whether the follow-all mode is enabled.
+func (root *Root) followAllEnabled() bool {
+	return root.followAllState.Load()
+}
+
+// setFollowAll sets the follow-all mode for all documents.
+func (root *Root) setFollowAll(enabled bool) {
+	root.FollowAll = enabled
+	root.followAllState.Store(enabled)
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	for _, doc := range root.DocList {
+		doc.setFollowAll(enabled)
+	}
+}
+
+// syncRuntimeFollowStates synchronizes the runtime follow-all flag across goroutines.
+func (root *Root) syncRuntimeFollowStates() {
+	root.followAllState.Store(root.FollowAll)
+	root.mu.Lock()
+	defer root.mu.Unlock()
+	for _, doc := range root.DocList {
+		doc.syncRuntimeFollowStates()
+	}
 }
 
 // SetWatcher sets file monitoring.
@@ -668,8 +696,9 @@ func (root *Root) prepareRun(ctx context.Context) error {
 
 	root.setViewModeConfig()
 	root.prepareAllDocuments()
+	root.syncRuntimeFollowStates()
 	// follow mode or follow all disables quit if the output fits on one screen.
-	if root.Doc.FollowMode || root.FollowAll {
+	if root.Doc.followModeEnabled() || root.followAllEnabled() {
 		root.Config.QuitSmall = false
 		root.Config.QuitSmallFilter = false
 	}
@@ -713,7 +742,10 @@ func (root *Root) prepareAllDocuments() {
 		doc.regexpCompile()
 
 		if doc.FollowName {
-			doc.FollowMode = true
+			doc.setFollowMode(true)
+		}
+		if root.FollowAll {
+			doc.setFollowAll(true)
 		}
 		if doc.ColumnWidth {
 			doc.ColumnMode = true
@@ -723,11 +755,14 @@ func (root *Root) prepareAllDocuments() {
 			doc.watchMode()
 			w = "(watch)"
 		}
+		doc.syncRuntimeFollowStates()
 		log.Printf("open [%d]%s%s\n", n, doc.FileName, w)
 	}
 
 	root.helpDoc.RunTimeSettings = updateRunTimeSettings(root.helpDoc.RunTimeSettings, root.Config.HelpDoc)
+	root.helpDoc.syncRuntimeFollowStates()
 	root.logDoc.RunTimeSettings = updateRunTimeSettings(root.logDoc.RunTimeSettings, root.Config.LogDoc)
+	root.logDoc.syncRuntimeFollowStates()
 }
 
 // Close closes the oviewer.

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -93,7 +93,7 @@ func (m *Document) followRead(reader *bufio.Reader) (*bufio.Reader, error) {
 	if m.checkClose() {
 		return reader, nil
 	}
-	if !m.FollowMode && !m.FollowAll {
+	if !m.followModeEnabled() && !m.followAllEnabled() {
 		return reader, nil
 	}
 

--- a/oviewer/status_line.go
+++ b/oviewer/status_line.go
@@ -91,16 +91,16 @@ func (root *Root) statusMode() string {
 		// Watch mode doubles as FollowSection mode.
 		return "(Watch)"
 	}
-	if root.Doc.FollowSection {
+	if root.Doc.followSectionEnabled() {
 		return "(Follow Section)"
 	}
-	if root.FollowAll {
+	if root.followAllEnabled() {
 		return "(Follow All)"
 	}
-	if root.Doc.FollowMode && root.Doc.FollowName {
+	if root.Doc.followModeEnabled() && root.Doc.FollowName {
 		return "(Follow Name)"
 	}
-	if root.Doc.FollowMode {
+	if root.Doc.followModeEnabled() {
 		return "(Follow Mode)"
 	}
 	return ""

--- a/oviewer/status_line_test.go
+++ b/oviewer/status_line_test.go
@@ -59,10 +59,10 @@ func TestRoot_statusMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := rootHelper(t)
 			root.Doc.WatchMode = tt.fields.WatchMode
-			root.Doc.FollowSection = tt.fields.FollowSection
-			root.FollowAll = tt.fields.FollowAll
+			root.Doc.setFollowSection(tt.fields.FollowSection)
+			root.setFollowAll(tt.fields.FollowAll)
 			root.Doc.FollowName = tt.fields.FollowName
-			root.Doc.FollowMode = tt.fields.FollowMode
+			root.Doc.setFollowMode(tt.fields.FollowMode)
 			root.Doc.pauseFollow = tt.fields.pauseFollow
 			if got := root.statusMode(); got != tt.want {
 				t.Errorf("Root.statusDisplay() = %v, want %v", got, tt.want)


### PR DESCRIPTION
Synchronize follow-mode, follow-all, and follow-section state across goroutines by introducing runtime atomic state and keeping it in sync with document initialization and toggles. Update follow checks, status display, and control flow to use the synchronized state so background follow behavior remains consistent.