### PR TITLE
fix: make close operations safe and idempotent across oviewer

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -381,6 +381,7 @@ func (root *Root) suspend(context.Context) {
 	}
 }
 
+// subShell starts a subshell and returns when it exits.
 func (root *Root) subShell(shell string) error {
 	if shell == "" {
 		shell = getShell()
@@ -391,7 +392,7 @@ func (root *Root) subShell(shell string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get stdin: %w", err)
 		}
-		defer tty.Close()
+		defer closeFile(tty)
 		stdin = tty
 	}
 	c := exec.Command(shell, "-l")

--- a/oviewer/control.go
+++ b/oviewer/control.go
@@ -152,8 +152,8 @@ func (m *Document) controlFile(sc controlSpecifier, reader *bufio.Reader) (*bufi
 		m.requestStart()
 		return reader, err
 	case requestClose:
-		err = m.close()
-		return reader, err
+		m.close()
+		return reader, nil
 	default:
 		panic(fmt.Sprintf("unexpected %s", sc.request))
 	}

--- a/oviewer/control_test.go
+++ b/oviewer/control_test.go
@@ -249,13 +249,13 @@ func CopyToTempFile(t *testing.T, fileName string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer orig.Close()
+	defer closeFile(orig)
 
 	dst, err := os.Create(fname)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dst.Close()
+	defer closeFile(dst)
 	if _, err := io.Copy(dst, orig); err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestDocument_requestFollow(t *testing.T) {
 			if err != nil {
 				t.Fatal("open error", tt.fields.FileName)
 			}
-			defer f.Close()
+			defer closeFile(f)
 			m.FollowMode = true
 			if err := m.ControlFile(f); err != nil {
 				t.Fatalf("Document.ControlFile() fatal = %v, wantErr %v", err, tt.wantErr)
@@ -306,7 +306,7 @@ func TestDocument_requestFollow(t *testing.T) {
 			if err != nil {
 				t.Fatal("open error", tt.fields.FileName)
 			}
-			defer af.Close()
+			defer closeFile(af)
 			if _, err := af.Write(tt.fields.appendBytes); err != nil {
 				t.Fatal("open error", tt.fields.FileName)
 			}

--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -284,11 +284,13 @@ type columnRange struct {
 	end   int
 }
 
+// MatchedLine represents a line that matches a search or filter criteria, containing the line number and the line content.
 type MatchedLine struct {
 	lineNum int
 	line    []byte
 }
 
+// MatchedLineList is a slice of MatchedLine, representing a list of matched lines.
 type MatchedLineList []MatchedLine
 
 // NewDocument creates and initializes a new [Document] with default settings.
@@ -821,4 +823,32 @@ func (m *Document) GetLine(n int) string {
 func (m *Document) LineString(n int) string {
 	str, _ := m.LineStr(n)
 	return str
+}
+
+// checkClose returns if the file is closed.
+func (m *Document) checkClose() bool {
+	return atomic.LoadInt32(&m.closed) == 1
+}
+
+// Close closes the File.
+// Record the last read position.
+func (m *Document) close() {
+	if m.checkClose() {
+		return
+	}
+
+	closeFile(m.file)
+	atomic.StoreInt32(&m.store.eof, 1)
+	atomic.StoreInt32(&m.closed, 1)
+	atomic.StoreInt32(&m.store.changed, 1)
+}
+
+// closeFile closes the given file and logs any errors encountered during the close operation.
+func closeFile(f io.Closer) {
+	if f == nil {
+		return
+	}
+	if err := f.Close(); err != nil {
+		log.Printf("close: %v", err)
+	}
 }

--- a/oviewer/edit.go
+++ b/oviewer/edit.go
@@ -56,7 +56,7 @@ func (root *Root) edit(context.Context) {
 			root.setMessageLog(err.Error())
 			return
 		}
-		defer tty.Close()
+		defer closeFile(tty)
 		stdin = tty
 	}
 
@@ -104,7 +104,7 @@ func (root *Root) saveTempFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer tempFile.Close()
+	defer closeFile(tempFile)
 
 	if err := root.tempExport(tempFile); err != nil {
 		log.Printf("Failed to export document to temporary file: %v", err)

--- a/oviewer/exec.go
+++ b/oviewer/exec.go
@@ -245,8 +245,8 @@ func ptyOutput(cmd *exec.Cmd) (io.Reader, io.Reader, error) {
 			log.Printf("pty wait: %v\n", err)
 		}
 		time.Sleep(100 * time.Millisecond)
-		stdout.Close()
-		stderr.Close()
+		closeFile(stdout)
+		closeFile(stderr)
 	}()
 
 	return so, se, nil

--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -48,8 +48,8 @@ func (root *Root) filterDocument(ctx context.Context, searcher Searcher) {
 	r, w := io.Pipe()
 	render, err := renderDoc(m, r)
 	if err != nil {
-		r.Close()
-		w.Close()
+		closeFile(r)
+		closeFile(w)
 		log.Printf("failed to filter document: %v\n", err)
 		return
 	}
@@ -84,7 +84,7 @@ func (root *Root) filterDocument(ctx context.Context, searcher Searcher) {
 
 // filterWriter searches and writes to filterDoc.
 func (m *Document) filterWriter(ctx context.Context, searcher Searcher, startLN int, filterDoc *filterDocument) {
-	defer filterDoc.w.Close()
+	defer closeFile(filterDoc.w)
 	for originLN, renderLN := startLN, startLN; ; {
 		select {
 		case <-ctx.Done():

--- a/oviewer/keybind.go
+++ b/oviewer/keybind.go
@@ -336,7 +336,7 @@ type KeyBindDescription struct {
 }
 
 var keyBindDescriptions = []KeyBindDescription{
-	// General
+	// Genaral.
 	{Group: GroupGeneral, Action: actionExit, Description: "quit"},
 	{Group: GroupGeneral, Action: actionCancel, Description: "cancel"},
 	{Group: GroupGeneral, Action: actionWriteExit, Description: "output screen and quit"},
@@ -352,7 +352,7 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupGeneral, Action: actionToggleMouse, Description: "enable/disable mouse"},
 	{Group: GroupGeneral, Action: actionSaveBuffer, Description: "save buffer to file"},
 
-	// Moving
+	// Moving.
 	{Group: GroupMoving, Action: actionMoveDown, Description: "forward by one line"},
 	{Group: GroupMoving, Action: actionMoveUp, Description: "backward by one line"},
 	{Group: GroupMoving, Action: actionMoveTop, Description: "go to top of document"},
@@ -372,7 +372,7 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupMoving, Action: actionGoLine, Description: "go to line (number, `.n`, or `n%`)"},
 	{Group: GroupMoving, Action: actionMarkNumber, Description: "go to mark number"},
 
-	// Sidebar
+	// Sidebar.
 	{Group: GroupSidebar, Action: actionSidebarHelp, Description: "toggle help in sidebar"},
 	{Group: GroupSidebar, Action: actionSidebarMarks, Description: "toggle mark list in sidebar"},
 	{Group: GroupSidebar, Action: actionSidebarDocList, Description: "toggle document list in sidebar"},
@@ -383,13 +383,13 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupSidebar, Action: actionSidebarLeft, Description: "scroll left in sidebar"},
 	{Group: GroupSidebar, Action: actionSidebarRight, Description: "scroll right in sidebar"},
 
-	// Move document
+	// Move document.
 	{Group: GroupDocList, Action: actionNextDoc, Description: "next document"},
 	{Group: GroupDocList, Action: actionPreviousDoc, Description: "previous document"},
 	{Group: GroupDocList, Action: actionCloseDoc, Description: "close current document"},
 	{Group: GroupDocList, Action: actionCloseAllFilter, Description: "close all filtered documents"},
 
-	// Mark position
+	// Mark position.
 	{Group: GroupMark, Action: actionMark, Description: "mark current position"},
 	{Group: GroupMark, Action: actionRemoveMark, Description: "remove mark at current position"},
 	{Group: GroupMark, Action: actionRemoveAllMark, Description: "remove all marks"},
@@ -397,14 +397,14 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupMark, Action: actionMovePrevMark, Description: "move to previous marked position"},
 	{Group: GroupMark, Action: actionMarkByPattern, Description: "mark all lines matching a pattern"},
 
-	// Search
+	// Search.
 	{Group: GroupSearch, Action: actionSearch, Description: "forward search mode"},
 	{Group: GroupSearch, Action: actionBackSearch, Description: "backward search mode"},
 	{Group: GroupSearch, Action: actionNextSearch, Description: "repeat forward search"},
 	{Group: GroupSearch, Action: actionNextBackSearch, Description: "repeat backward search"},
 	{Group: GroupSearch, Action: actionFilter, Description: "filter lines by pattern"},
 
-	// Change display
+	// Change display.
 	{Group: GroupChange, Action: actionWrap, Description: "wrap toggle (character based)"},
 	{Group: GroupChange, Action: actionWordWrap, Description: "word wrap toggle"},
 	{Group: GroupChange, Action: actionColumnMode, Description: "column mode toggle"},
@@ -419,7 +419,7 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupChange, Action: actionStatusLine, Description: "status line toggle"},
 	{Group: GroupChange, Action: actionStyleToggle, Description: "suppress style highlight by number"},
 
-	// Change Display with Input
+	// Change display with input.
 	{Group: GroupChangeInput, Action: actionViewMode, Description: "view mode selection"},
 	{Group: GroupChangeInput, Action: actionDelimiter, Description: "column delimiter string"},
 	{Group: GroupChangeInput, Action: actionHeader, Description: "number of header lines"},
@@ -431,12 +431,12 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupChangeInput, Action: actionVerticalHeader, Description: "number of vertical header characters"},
 	{Group: GroupChangeInput, Action: actionHeaderColumn, Description: "number of header columns"},
 
-	// Column operation
+	// Column operation.
 	{Group: GroupColumn, Action: actionFixedColumn, Description: "toggle fixed header column"},
 	{Group: GroupColumn, Action: actionShrinkColumn, Description: "shrink column toggle (align mode only)"},
 	{Group: GroupColumn, Action: actionRightAlign, Description: "right align column toggle (align mode only)"},
 
-	// Section operation
+	// Section operation.
 	{Group: GroupSection, Action: actionSection, Description: "section delimiter regular expression"},
 	{Group: GroupSection, Action: actionSectionStart, Description: "section start position"},
 	{Group: GroupSection, Action: actionNextSection, Description: "next section"},
@@ -446,13 +446,13 @@ var keyBindDescriptions = []KeyBindDescription{
 	{Group: GroupSection, Action: actionSectionNum, Description: "number of section header lines"},
 	{Group: GroupSection, Action: actionHideOther, Description: `hide "other" section toggle`},
 
-	// Close and reload
+	// Close and reload.
 	{Group: GroupClose, Action: actionCloseFile, Description: "close file"},
 	{Group: GroupClose, Action: actionReload, Description: "reload file"},
 	{Group: GroupClose, Action: actionWatch, Description: "toggle watch mode"},
 	{Group: GroupClose, Action: actionWatchInterval, Description: "set watch interval"},
 
-	// Key binding when typing
+	// Key binding when typing.
 	{Group: GroupTyping, Action: inputCaseSensitive, Description: "case-sensitive toggle"},
 	{Group: GroupTyping, Action: inputSmartCaseSensitive, Description: "smart case-sensitive toggle"},
 	{Group: GroupTyping, Action: inputRegexpSearch, Description: "regular expression search toggle"},

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -625,7 +625,11 @@ func (root *Root) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create watcher: %w", err)
 	}
-	defer watcher.Close()
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			log.Println(err)
+		}
+	}()
 	root.SetWatcher(watcher)
 	if err := root.prepareRun(ctx); err != nil {
 		return err

--- a/oviewer/reader.go
+++ b/oviewer/reader.go
@@ -385,24 +385,3 @@ func (m *Document) reset() {
 	atomic.StoreInt32(&m.store.changed, 1)
 	m.ClearCache()
 }
-
-// checkClose returns if the file is closed.
-func (m *Document) checkClose() bool {
-	return atomic.LoadInt32(&m.closed) == 1
-}
-
-// Close closes the File.
-// Record the last read position.
-func (m *Document) close() error {
-	if m.checkClose() {
-		return nil
-	}
-
-	if err := m.file.Close(); err != nil {
-		return fmt.Errorf("close: %w", err)
-	}
-	atomic.StoreInt32(&m.store.eof, 1)
-	atomic.StoreInt32(&m.closed, 1)
-	atomic.StoreInt32(&m.store.changed, 1)
-	return nil
-}

--- a/oviewer/save.go
+++ b/oviewer/save.go
@@ -36,7 +36,7 @@ func (root *Root) saveBuffer(input string) {
 		root.setMessageLogf("cannot save: %s:%s", fileName, err)
 		return
 	}
-	defer file.Close()
+	defer closeFile(file)
 
 	if err := root.Doc.Export(file, root.Doc.BufStartNum(), root.Doc.BufEndNum()); err != nil {
 		root.setMessageLogf("cannot save: %s:%s", fileName, err)


### PR DESCRIPTION
- centralize close handling with a shared helper that logs close errors
- make document close idempotent and stop propagating close errors on requestClose
- replace direct Close calls with safe close helper in related paths
- add/adjust comments for clarity