### PR TITLE
Fix force-screen to skip redirect setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,9 @@ It supports various compressed files(gzip, bzip2, zstd, lz4, and xz).
 		oviewer.OverLineStyle = oviewer.ToTcellStyle(config.StyleOverLine)
 		oviewer.MemoryLimit = config.MemoryLimit
 		oviewer.MemoryLimitFile = config.MemoryLimitFile
-		SetRedirect()
+		if !forceScreen {
+			SetRedirect()
+		}
 		// Do not display the screen if redirected (unless forceScreen is specified).
 		if oviewer.STDOUTPIPE != nil && !forceScreen {
 			return copyOutput(args)


### PR DESCRIPTION
Only call SetRedirect when force-screen is disabled. This prevents redirected runs with force-screen from mixing full file copy output with exit output, and keeps the option behavior consistent with showing the interactive screen.