### PR TITLE
Fix extra blank lines when writing with hidden sections

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -923,18 +923,6 @@ func (root *Root) WriteQuit(ctx context.Context) {
 	root.Quit(ctx)
 }
 
-// bottomSectionLN returns the number of lines to write.
-func (root *Root) bottomSectionLN(ctx context.Context) int {
-	if root.Doc.SectionDelimiter == "" {
-		return root.Config.AfterWriteOriginal
-	}
-	lN, err := root.Doc.nextSection(ctx, root.Doc.topLN+root.Doc.firstLine()-root.Doc.SectionStartPosition)
-	if err != nil {
-		return root.Config.AfterWriteOriginal
-	}
-	return lN - (root.Doc.topLN + root.Doc.firstLine() - root.Doc.SectionStartPosition)
-}
-
 // toggleFixedColumn toggles the fixed column.
 func (root *Root) toggleFixedColumn(context.Context) {
 	cursor := root.Doc.columnCursor - root.Doc.columnStart + 1

--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -911,10 +911,6 @@ func (root *Root) WriteQuit(ctx context.Context) {
 	}
 
 	root.Config.IsWriteOnExit = true
-	if root.Doc.HideOtherSection && root.Config.AfterWriteOriginal == 0 {
-		// hide other section.
-		root.Config.AfterWriteOriginal = root.bottomSectionLN(ctx)
-	}
 
 	// Do not write if BeforeWriteOriginal is set (greater than 0).
 	if root.Config.BeforeWriteOriginal > 0 {

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1347,7 +1347,7 @@ func TestRoot_WriteQuit(t *testing.T) {
 				sectionDelimiter: "",
 				HideOtherSection: false,
 			},
-			want: 0,
+			want: 10,
 		},
 		{
 			name: "testWriteQuit2",
@@ -1356,7 +1356,7 @@ func TestRoot_WriteQuit(t *testing.T) {
 				sectionDelimiter: "",
 				HideOtherSection: true,
 			},
-			want: 0,
+			want: 10,
 		},
 		{
 			name: "testWriteQuit3",
@@ -1374,7 +1374,7 @@ func TestRoot_WriteQuit(t *testing.T) {
 				sectionDelimiter: "^notfound",
 				HideOtherSection: true,
 			},
-			want: 0,
+			want: 10,
 		},
 	}
 	for _, tt := range tests {
@@ -1383,11 +1383,13 @@ func TestRoot_WriteQuit(t *testing.T) {
 			root.prepareScreen()
 			ctx := context.Background()
 			root.setSectionDelimiter(tt.fields.sectionDelimiter)
-			root.prepareDraw(ctx)
+			root.Doc.SectionHeader = true
 			root.Doc.HideOtherSection = tt.fields.HideOtherSection
+			root.prepareDraw(ctx)
+			root.draw(ctx)
 			root.WriteQuit(ctx)
-			if got := root.Config.AfterWriteOriginal; got != tt.want {
-				t.Errorf("WriteQuit() AfterWriteOriginal = %v, want %v", got, tt.want)
+			if got := len(root.OnExit); got != tt.want {
+				t.Errorf("WriteQuit() OnExit = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -460,8 +460,8 @@ func (root *Root) sectionLineHighlight(y int, line LineC) {
 }
 
 // hideOtherSection hides other sections.
-func (root *Root) hideOtherSection(y int, line LineC) {
-	if line.section <= 1 { // 1 is the first section.
+func (root *Root) hideOtherSection(y int, lineC LineC) {
+	if lineC.section <= 1 { // 1 is the first section.
 		return
 	}
 	root.clearEOL(root.Doc.leftMargin, y, defaultStyle)

--- a/oviewer/oviewer.go
+++ b/oviewer/oviewer.go
@@ -1065,12 +1065,12 @@ func (root *Root) drawVirtualScreen() (int, int, error) {
 	root.prepareScreen()
 	root.prepareDraw(ctx)
 	root.draw(ctx)
-	start, end := contentRange(root.scr)
+	start, end := contentRange(root.scr, root.Doc.HideOtherSection)
 	return start, end, nil
 }
 
 // contentRange returns the range of valid content on the screen.
-func contentRange(scr SCR) (int, int) {
+func contentRange(scr SCR, isHide bool) (int, int) {
 	start := 0
 	end := 0
 	valid := false
@@ -1078,7 +1078,11 @@ func contentRange(scr SCR) (int, int) {
 		if y >= len(scr.numbers) {
 			break
 		}
-		if !scr.lines[scr.numbers[y].number].valid {
+		lineC := scr.lines[scr.numbers[y].number]
+		if !lineC.valid {
+			continue
+		}
+		if isHide && lineC.section >= 2 {
 			continue
 		}
 		if !valid {
@@ -1093,7 +1097,7 @@ func contentRange(scr SCR) (int, int) {
 // ScreenContent returns the screen content.
 func (root *Root) ScreenContent() []string {
 	root.Screen.Sync()
-	start, end := contentRange(root.scr)
+	start, end := contentRange(root.scr, root.Doc.HideOtherSection)
 	end += root.Config.AfterWriteOriginal
 	start -= root.Config.BeforeWriteOriginal
 	end = max(end, start)


### PR DESCRIPTION
Determine the output range based on whether a section should actually be written when HideOtherSection is enabled, so quitting after writing does not emit blank lines for hidden sections.