### PR TITLE
Add --mark-by-pattern flag to mark lines matching a pattern on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,9 +36,11 @@ var (
 
 	// filter is filter pattern.
 	filter string
-
 	// non match filter pattern.
 	nonMatchFilter string
+
+	// markByPattern is mark by pattern.
+	markByPattern string
 
 	// ver is version information.
 	ver bool
@@ -257,6 +259,9 @@ func RunOviewer(args []string) error {
 	if nonMatchFilter != "" {
 		ov.Filter(nonMatchFilter, true)
 	}
+	if markByPattern != "" {
+		ov.MarkByPattern(markByPattern)
+	}
 
 	if ov.Config.QuitSmall && (filter != "" || nonMatchFilter != "") {
 		ov.Config.QuitSmallFilter = true
@@ -469,6 +474,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&pattern, "pattern", "", "", "initial search pattern applied on startup")
 	rootCmd.PersistentFlags().StringVarP(&filter, "filter", "", "", "show only lines matching this pattern")
 	rootCmd.PersistentFlags().StringVarP(&nonMatchFilter, "non-match-filter", "", "", "hide lines matching this pattern")
+	rootCmd.PersistentFlags().StringVarP(&markByPattern, "mark-by-pattern", "", "", "mark lines matching this pattern")
 	rootCmd.PersistentFlags().BoolVarP(&oviewer.SkipExtract, "skip-extract", "", false, "read compressed files as raw bytes without decompressing")
 
 	// Config.General

--- a/oviewer/mark.go
+++ b/oviewer/mark.go
@@ -157,6 +157,24 @@ func (list MatchedLineList) contains(lineNumber int) bool {
 	return false
 }
 
+// MarkByPattern marks lines matching the pattern.
+func (root *Root) MarkByPattern(str string) {
+	root.input.value = str
+	go func() {
+		root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
+		root.sendMarkByPattern(str)
+	}()
+}
+
+// sendMarkByPattern sends the mark by pattern event to the document.
+func (root *Root) sendMarkByPattern(str string) {
+	ev := &eventInputSearch{
+		searchType: markByPattern,
+		value:      str,
+	}
+	root.postEvent(ev)
+}
+
 // eventAddMarks represents an event to add multiple marks.
 type eventAddMarks struct {
 	tcell.EventTime


### PR DESCRIPTION
Add a new `--mark-by-pattern` CLI flag that marks all lines matching a given pattern when ov starts. Introduces `MarkByPattern` on Root which waits for EOF then fires a markByPattern search event via `sendMarkByPattern`.