### PR TITLE
Separate first-search execution from input-search events

### DIFF
--- a/oviewer/event.go
+++ b/oviewer/event.go
@@ -99,8 +99,8 @@ func (root *Root) event(ctx context.Context, ev tcell.Event) bool {
 		root.setMultiColor(ev.value)
 	case *eventSaveBuffer:
 		root.saveBuffer(ev.value)
-	case *eventInputSearch:
-		root.firstSearch(ctx, ev.searchType)
+	case *eventFirstSearch:
+		root.firstSearch(ctx, ev.value, ev.searchType)
 	case *eventSkipLines:
 		root.setSkipLines(ev.value)
 	case *eventTabWidth:

--- a/oviewer/filter.go
+++ b/oviewer/filter.go
@@ -16,20 +16,10 @@ type filterDocument struct {
 // Filter fires the filter event.
 func (root *Root) Filter(str string, nonMatch bool) {
 	root.Doc.nonMatch = nonMatch
-	root.input.value = str
 	go func() {
 		root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
-		root.sendFilter(str)
+		root.sendFirstSearch(str, filter)
 	}()
-}
-
-// sendFilter sends the filter event to the document.
-func (root *Root) sendFilter(str string) {
-	ev := &eventInputSearch{
-		searchType: filter,
-		value:      str,
-	}
-	root.postEvent(ev)
 }
 
 // filter filters the document by the input value.

--- a/oviewer/input_search.go
+++ b/oviewer/input_search.go
@@ -81,6 +81,10 @@ func (root *Root) setPromptOpt() {
 }
 
 // eventInputSearch represents the search input mode.
+//
+// Historically this type worked as a tcell event, but now it is used only
+// as input-mode state and behavior holder. The event-style name is kept for
+// compatibility with existing code and terminology.
 type eventInputSearch struct {
 	tcell.EventTime
 	clist      *candidate
@@ -129,11 +133,18 @@ func (e *eventInputSearch) Prompt() string {
 }
 
 // Confirm returns the event when the input is confirmed.
+// It returns eventFirstSearch instead of eventInputSearch to avoid re-entering
+// the input mode.
 func (e *eventInputSearch) Confirm(str string) tcell.Event {
 	e.value = stripBackSlash(str)
 	e.clist.toLast(str)
-	e.SetEventNow()
-	return e
+
+	// Return eventFirstSearch instead of eventInputSearch to avoid re-entering the input mode.
+	ev := &eventFirstSearch{}
+	ev.value = e.value
+	ev.searchType = e.searchType
+	ev.SetEventNow()
+	return ev
 }
 
 // Up returns strings when the up key is pressed during input.

--- a/oviewer/input_search_test.go
+++ b/oviewer/input_search_test.go
@@ -59,11 +59,12 @@ func Test_eventInputSearch_Confirm(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &eventInputSearch{
-				EventTime: tt.fields.EventTime,
-				clist:     tt.fields.clist,
-				value:     tt.fields.value,
+				EventTime:  tt.fields.EventTime,
+				clist:      tt.fields.clist,
+				value:      tt.fields.value,
+				searchType: forward,
 			}
-			if got := e.Confirm(tt.args.str); got.(*eventInputSearch).value != tt.want {
+			if got := e.Confirm(tt.args.str); got.(*eventFirstSearch).value != tt.want {
 				t.Errorf("eventInputSearch.Confirm() = %v, want %v", got, tt.want)
 			}
 		})

--- a/oviewer/mark.go
+++ b/oviewer/mark.go
@@ -159,7 +159,6 @@ func (list MatchedLineList) contains(lineNumber int) bool {
 
 // MarkByPattern marks lines matching the pattern.
 func (root *Root) MarkByPattern(str string) {
-	root.input.value = str
 	go func() {
 		root.Doc.WaitEOFWithTimeout(root.Config.ReadWaitTime)
 		root.sendMarkByPattern(str)
@@ -168,11 +167,7 @@ func (root *Root) MarkByPattern(str string) {
 
 // sendMarkByPattern sends the mark by pattern event to the document.
 func (root *Root) sendMarkByPattern(str string) {
-	ev := &eventInputSearch{
-		searchType: markByPattern,
-		value:      str,
-	}
-	root.postEvent(ev)
+	root.sendFirstSearch(str, markByPattern)
 }
 
 // eventAddMarks represents an event to add multiple marks.

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -604,17 +604,34 @@ func (root *Root) startSearchLN() int {
 }
 
 // firstSearch performs the first search immediately after the input.
-func (root *Root) firstSearch(ctx context.Context, t searchType) {
+func (root *Root) firstSearch(ctx context.Context, value string, t searchType) {
 	switch t {
 	case forward:
-		root.forwardSearch(ctx, root.input.value, 0)
+		root.forwardSearch(ctx, value, 0)
 	case backward:
-		root.backSearch(ctx, root.input.value, 0)
+		root.backSearch(ctx, value, 0)
 	case filter:
-		root.filter(ctx, root.input.value)
+		root.filter(ctx, value)
 	case markByPattern:
-		root.markByPattern(ctx, root.input.value)
+		root.markByPattern(ctx, value)
 	}
+}
+
+// eventFirstSearch represents a first search execution event.
+// It is used by both confirmed input and non-interactive API calls.
+type eventFirstSearch struct {
+	tcell.EventTime
+	value      string
+	searchType searchType
+}
+
+// sendFirstSearch fires the eventFirstSearch event.
+func (root *Root) sendFirstSearch(value string, t searchType) {
+	ev := &eventFirstSearch{}
+	ev.value = value
+	ev.searchType = t
+	ev.SetEventNow()
+	root.postEvent(ev)
 }
 
 // forwardSearch performs the forward search.


### PR DESCRIPTION
Introduce a dedicated first-search event for confirmed input and non-interactive search/filter/mark actions, avoiding re-entry into input mode and updating related tests.