### PR TITLE
Fix wrapnum calculation in drawBody

### DIFF
--- a/oviewer/draw.go
+++ b/oviewer/draw.go
@@ -47,15 +47,15 @@ func (root *Root) draw(ctx context.Context) {
 // drawBody sets bottomLN and bottomLX of the document.
 func (root *Root) drawBody() {
 	m := root.Doc
-	lX := m.topLX
+	markStyleWidth := min(m.width, m.MarkStyleWidth)
 	lN := m.topLN + root.scr.headerEnd
+	lX := 0
 	wrapNum := 0
-	if !m.WrapMode { // If WrapMode is off, topLX is always 0.
-		lX = 0
+	if m.WrapMode {
+		lX = m.topLX
 		wrapNum = m.numOfWrap(lX, lN)
 	}
 
-	markStyleWidth := min(root.Doc.width, root.Doc.MarkStyleWidth)
 	for y := m.headerHeight; y < root.scr.vHeight-root.scr.statusLineHeight; y++ {
 		lineC, ok := root.scr.lines[lN]
 		if !ok {


### PR DESCRIPTION
Adjust wrap number calculation to respect wrap mode and use the correct horizontal offset when rendering the body. This prevents incorrect wrap behavior during drawing.