### PR TITLE
fix: panic when --skip-lines exceeds the file length with --column-width

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -782,6 +782,10 @@ func (m *Document) setColumnWidths() {
 	header := m.Header - 1
 	header = max(header, 0)
 	tl := min(1000, len(m.store.chunks[0].lines))
+	// Stop guessing if the skipped lines exceed the lines to guess from.
+	if m.SkipLines >= tl {
+		return
+	}
 	lines := m.store.chunks[0].lines[m.SkipLines:tl]
 	buf := make([]string, len(lines))
 	for n, line := range lines {

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -601,6 +601,50 @@ func TestRoot_styleContent(t *testing.T) {
 	}
 }
 
+func TestDocument_setColumnWidthsSkipLines(t *testing.T) {
+	type fields struct {
+		SkipLines int
+	}
+	type want struct {
+		columnWidths int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "Test setColumnWidthsSkipLinesWithin",
+			fields: fields{
+				SkipLines: 1,
+			},
+			want: want{
+				columnWidths: 2,
+			},
+		},
+		{
+			name: "Test setColumnWidthsSkipLinesOverBuffer",
+			fields: fields{
+				SkipLines: 10,
+			},
+			want: want{
+				columnWidths: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := docHelper(t, "a b c\nd e f\ng h i\n")
+			m.ColumnWidth = true
+			m.SkipLines = tt.fields.SkipLines
+			m.setColumnWidths()
+			if len(m.columnWidths) != tt.want.columnWidths {
+				t.Errorf("columnWidths len got: %d, want: %d", len(m.columnWidths), tt.want.columnWidths)
+			}
+		})
+	}
+}
+
 func TestRoot_searchHighlight(t *testing.T) {
 	tcellNewScreen = fakeScreen
 	searchHighlight := tcell.StyleDefault.Reverse(true)


### PR DESCRIPTION
## What's broken

`setColumnWidths` panics when `SkipLines` is larger than the buffer it is guessing from.

```
panic: runtime error: slice bounds out of range [10:3]
	github.com/noborus/ov/oviewer.(*Document).setColumnWidths  oviewer/document.go:785
	github.com/noborus/ov/oviewer.(*Root).prepareDraw          oviewer/prepare_draw.go:148
```

```go
m := docHelper(t, "a b c\nd e f\ng h i\n")
m.ColumnWidth = true
m.SkipLines = 10
m.setColumnWidths()   // panic
```

`tl` is clamped with `min(1000, len(...))` but `m.SkipLines` never is, so `lines[m.SkipLines:tl]` goes out of range on any file shorter than the skip. Reachable through `--column-width`, `--align` and `--wrap word`, and through `prepareDraw` from the interactive ctrl+s path.

## The fix

Return early when the skip covers everything there is to guess from, next to the two early returns the function already has. Guessing from zero lines has no meaningful answer, and `columnWidths` staying empty is exactly what the existing `len(buf) < 20` return already produces for a too-short buffer.

After, `--skip-lines 10 --column-width` on a three-line file prints the file unchanged and exits 0.

## What I could not reproduce, and what that means

I could only trigger this from Go, not from a shell. Without a TTY `ov` writes the file straight out and never reaches `prepareDraw`, so I have no CLI reproduction to paste, and I could not drive the interactive ctrl+s path either.

What I did verify: with `SkipLines` set the way `setSkipLines` would set it for a 25-row terminal, `prepareDraw` panics with `slice bounds out of range [10:1]` before the change and passes after. So the guard covers the interactive path too, but I am relying on reading `prepareDraw` for that rather than on having driven the UI.

One thing I did not touch, since it is not the crash: `specifyOnScreen(input, root.scr.vHeight-1)` in `action.go` validates interactive skip-lines against the screen height rather than the buffer length, so it still accepts values larger than the file. With this change that is a harmless no-op instead of a panic. Happy to follow up there if you would rather it rejected them.

## Verification

`TestDocument_setColumnWidthsSkipLines` in `oviewer/prepare_draw_test.go`, table-driven in the style of its neighbours. Two cases: `SkipLines: 10` over a 3-line buffer expects no column widths, and `SkipLines: 1` expects the normal 2, so an over-clamping fix fails it too.

With the guard reverted the first case panics with the message above. `go test ./...` passes and `go vet` is clean.
