### PR TITLE
fix: dot percentages are off by ten beyond one digit (.25, .05)

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -782,12 +782,13 @@ func calcPosition(str string, length int) (float64, error) {
 
 	var p float64 = 0
 	if strings.HasPrefix(str, ".") {
-		str = strings.TrimLeft(str, ".")
+		// ".25" is the fraction 0.25, so parse it whole rather than
+		// stripping the dot and dividing by a fixed 10.
 		i, err := strconv.ParseFloat(str, 64)
 		if err != nil {
 			return 0, err
 		}
-		p = i / 10
+		p = i
 	}
 	if strings.HasSuffix(str, "%") {
 		str = strings.TrimRight(str, "%")

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -220,6 +220,22 @@ func Test_position(t *testing.T) {
 			want: 15,
 		},
 		{
+			name: "test.25",
+			args: args{
+				str:    ".25",
+				height: 40,
+			},
+			want: 10,
+		},
+		{
+			name: "test.05",
+			args: args{
+				str:    ".05",
+				height: 40,
+			},
+			want: 2,
+		},
+		{
 			name: "test20%",
 			args: args{
 				str:    "20%",


### PR DESCRIPTION
## What's broken

The dot form of a percentage is only correct for a single digit. `calcPosition` strips the dot and divides by a hard-coded 10, so anything with two digits after the dot is off by a factor of ten, and a leading zero is ignored entirely.

Against a 1000-line length:

| input | before | after | expected |
|---|---|---|---|
| `.5` | 500 | 500 | 500 |
| `.05` | 500 | 50 | 50 |
| `.25` | 2500 | 250 | 250 |
| `.50` | 5000 | 500 | 500 |
| `..5` | 500 | error | error |

`.05` and `.5` are the same value, and `.25` lands past the end of the file. Visible through `--jump-target`:

```
$ ov --jump-target 25% --pattern 100 nums.txt    # 200-line file
94
$ ov --jump-target .25 --pattern 100 nums.txt
40
```

Two spellings of the same target, two different answers. The same function drives `goLine`, so typing `.25` at the `g` prompt on a 200-line file clamps to 200 instead of jumping to 50.

The README says ". (dot) can be used to specify a percentage", and `goLine`'s own doc comment gives `.5 -> 50%`, so the intended meaning is documented in two places.

## The fix

`.25` already is the float 0.25, so parse it whole instead of stripping the dot and dividing:

```go
i, err := strconv.ParseFloat(str, 64)   // ".25" -> 0.25
p = i
```

`.5` keeps working, since 0.5 was already what the old path arrived at for single digits.

`10.5` is unaffected: it has no leading dot, so it never enters this branch. That matters because in `goLine` it means line 10 plus 5 wrap lines, not a percentage.

One deliberate behaviour change beyond the arithmetic: `..5` used to parse as 50%, because `TrimLeft` strips a character class rather than one prefix character. It is now a parse error, which is what the existing `.i` test case already expects for malformed input.

## Verification

Two cases added to the `Test_position` table, `.25` and `.05` against a height of 40, expecting 10 and 2. With the change reverted they fail with 100 and 20, so both are load-bearing.

The existing `.5` and `.3` cases are unchanged and still pass, which is the guard against a fix that breaks the single-digit form. `go test ./...` passes and `go vet` is clean.
