### PR TITLE
fix: a delimiter inside a quoted field at line start splits the column

### DIFF
--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -69,26 +69,36 @@ func allIndex(s string, substr string, reg *regexp.Regexp) [][]int {
 }
 
 // allStringIndex returns all matching string positions.
+// Delimiters inside a double-quoted field are not treated as delimiters.
 func allStringIndex(s string, substr string) [][]int {
 	if len(substr) == 0 {
 		return nil
 	}
 	var result [][]int
 	width := len(substr)
-	for pos, offSet := strings.Index(s, substr), 0; pos != -1; {
+	offSet := 0
+	// The first field may also be quoted, so skip it before the first search.
+	if len(s) > 0 && s[0] == '"' {
+		s, offSet = skipQuoted(s, offSet)
+	}
+	for pos := strings.Index(s, substr); pos != -1; pos = strings.Index(s, substr) {
 		s = s[pos+width:]
 		result = append(result, []int{pos + offSet, pos + offSet + width})
 		offSet += pos + width
 
 		if len(s) > 0 && s[0] == '"' {
-			qpos := strings.Index(s[1:], `"`)
-			s = s[qpos+2:]
-			offSet += qpos + 2
+			s, offSet = skipQuoted(s, offSet)
 		}
-
-		pos = strings.Index(s, substr)
 	}
 	return result
+}
+
+// skipQuoted skips the double-quoted field at the beginning of s.
+// It returns the remainder of s and the updated offset.
+// If the quote is not closed, only the opening quote is skipped.
+func skipQuoted(s string, offSet int) (string, int) {
+	qpos := strings.Index(s[1:], `"`)
+	return s[qpos+2:], offSet + qpos + 2
 }
 
 // writeLine writes a line to w.

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -65,20 +65,20 @@ func allIndex(s string, substr string, reg *regexp.Regexp) [][]int {
 	if reg != nil {
 		return reg.FindAllStringIndex(s, -1)
 	}
-	return allStringIndex(s, substr)
+	return allDelimiterIndex(s, substr)
 }
 
-// allStringIndex returns all matching string positions.
-// Delimiters inside a double-quoted field are not treated as delimiters.
-func allStringIndex(s string, substr string) [][]int {
+// allDelimiterIndex returns all delimiter positions.
+// A delimiter inside a double-quoted field is part of the field, not a
+// delimiter, including when the quoted field is the first one on the line.
+func allDelimiterIndex(s string, substr string) [][]int {
 	if len(substr) == 0 {
 		return nil
 	}
 	var result [][]int
 	width := len(substr)
 	offSet := 0
-	// The first field may also be quoted, so skip it before the first search.
-	if len(s) > 0 && s[0] == '"' {
+	if strings.HasPrefix(s, `"`) {
 		s, offSet = skipQuoted(s, offSet)
 	}
 	for pos := strings.Index(s, substr); pos != -1; pos = strings.Index(s, substr) {
@@ -86,19 +86,42 @@ func allStringIndex(s string, substr string) [][]int {
 		result = append(result, []int{pos + offSet, pos + offSet + width})
 		offSet += pos + width
 
-		if len(s) > 0 && s[0] == '"' {
+		if strings.HasPrefix(s, `"`) {
 			s, offSet = skipQuoted(s, offSet)
 		}
 	}
 	return result
 }
 
-// skipQuoted skips the double-quoted field at the beginning of s.
-// It returns the remainder of s and the updated offset.
-// If the quote is not closed, only the opening quote is skipped.
+// skipQuoted skips the double-quoted field at the beginning of s and returns
+// the remainder with the updated offset. An unclosed quote skips only the
+// opening quote, which is what the delimiter search did before.
 func skipQuoted(s string, offSet int) (string, int) {
 	qpos := strings.Index(s[1:], `"`)
 	return s[qpos+2:], offSet + qpos + 2
+}
+
+// allStringIndex returns all matching string positions.
+func allStringIndex(s string, substr string) [][]int {
+	if len(substr) == 0 {
+		return nil
+	}
+	var result [][]int
+	width := len(substr)
+	for pos, offSet := strings.Index(s, substr), 0; pos != -1; {
+		s = s[pos+width:]
+		result = append(result, []int{pos + offSet, pos + offSet + width})
+		offSet += pos + width
+
+		if len(s) > 0 && s[0] == '"' {
+			qpos := strings.Index(s[1:], `"`)
+			s = s[qpos+2:]
+			offSet += qpos + 2
+		}
+
+		pos = strings.Index(s, substr)
+	}
+	return result
 }
 
 // writeLine writes a line to w.

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -502,6 +502,66 @@ func Test_allStringIndex(t *testing.T) {
 				{9, 10},
 			},
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := allStringIndex(tt.args.s, tt.args.substr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_allDelimiterIndex(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		s      string
+		substr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]int
+	}{
+		{
+			name: "test1",
+			args: args{
+				s:      "a,b,c",
+				substr: ",",
+			},
+			want: [][]int{
+				{1, 2},
+				{3, 4},
+			},
+		},
+		{
+			name: "testNone",
+			args: args{
+				s:      "a,b,c",
+				substr: "@",
+			},
+			want: nil,
+		},
+		{
+			name: "testNoSubstr",
+			args: args{
+				s:      "a,b,c",
+				substr: "",
+			},
+			want: nil,
+		},
+		{
+			name: "testDoubleQuote",
+			args: args{
+				s:      `a,"b,c",d`,
+				substr: ",",
+			},
+			want: [][]int{
+				{1, 2},
+				{7, 8},
+			},
+		},
 		{
 			name: "testLeadingDoubleQuote",
 			args: args{
@@ -546,8 +606,8 @@ func Test_allStringIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := allStringIndex(tt.args.s, tt.args.substr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("allIndex() = %v, want %v", got, tt.want)
+			if got := allDelimiterIndex(tt.args.s, tt.args.substr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allDelimiterIndex() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -502,6 +502,46 @@ func Test_allStringIndex(t *testing.T) {
 				{9, 10},
 			},
 		},
+		{
+			name: "testLeadingDoubleQuote",
+			args: args{
+				s:      `"a,b",c,d`,
+				substr: ",",
+			},
+			want: [][]int{
+				{5, 6},
+				{7, 8},
+			},
+		},
+		{
+			name: "testLeadingDoubleQuoteOnly",
+			args: args{
+				s:      `"a,b"`,
+				substr: ",",
+			},
+			want: nil,
+		},
+		{
+			name: "testLeadingEmptyDoubleQuote",
+			args: args{
+				s:      `"",a,b`,
+				substr: ",",
+			},
+			want: [][]int{
+				{2, 3},
+				{4, 5},
+			},
+		},
+		{
+			name: "testLeadingUnclosedDoubleQuote",
+			args: args{
+				s:      `"a,b`,
+				substr: ",",
+			},
+			want: [][]int{
+				{2, 3},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A delimiter inside a double-quoted field is correctly ignored, unless the quoted
field is the first one on the line.

`al.csv`:

```
"a,b",xx,y
longer,c,dd
```

with `--column-delimiter=, --column-mode --align`:

```
before:
"a    ,b",xx,y
longer,c ,dd

after:
"a,b" ,xx,y
longer,c ,dd
```

Align mode makes it visible: the padding is inserted *inside* the quoted field,
because `"a` and `b"` are being treated as two columns. In column mode the cursor
column is the truncated `"a` rather than the whole field.

## Cause

`allStringIndex` skips a quoted field only after it has already found a
delimiter:

```go
for pos, offSet := strings.Index(s, substr), 0; pos != -1; {
    s = s[pos+width:]
    ...
    if len(s) > 0 && s[0] == '"' {   // only reached after the first match
```

A quote at position 0 is never examined, so the delimiter inside the first field
is counted.

## The fix

Check for a leading quote before the first search, and pull the skip into a
`skipQuoted` helper so both places do the same thing.

An unclosed quote keeps its current behaviour: `strings.Index` returns -1 and
`s[qpos+2:]` becomes `s[1:]`, so only the opening quote is skipped and the rest
of the line is scanned as usual. That matches what the original code did for a
mid-line unclosed quote, and keeps this change to the one bug.

## Verification

Two cases in `Test_allStringIndex`, one for a line that is only a quoted field
and one for a quoted field followed by more columns.

Removing the leading-quote skip fails both:

```
--- FAIL: Test_allStringIndex/testLeadingDoubleQuoteOnly
    utils_test.go:550: allIndex() = [[2 3]], want []
--- FAIL: Test_allStringIndex/testLeadingDoubleQuote
    utils_test.go:550: allIndex() = [[2 3] [5 6] [7 8]], want [[5 6] [7 8]]
```

The existing mid-line quoted cases pass under that mutation, which is what pins
the behaviour the change must not alter.

`go test ./...` is ok across all packages. `gofumpt -l` is clean on both files I
touched. No new fixture files, so the `t.TempDir()` and Windows CI hazard does
not arise.

`golangci-lint` reports 9 issues repo-wide and `gofumpt -l` flags `draw.go` and
`move_updown.go`, all pre-existing on master in files I did not touch.

*Disclosure: written with AI assistance (Claude Code). The before and after come from running binaries built from each tree in a real terminal under tmux, and I ran the mutation check myself.*
