### PR TITLE
Default the interactive header column prompt to the first column

### DIFF
--- a/oviewer/action.go
+++ b/oviewer/action.go
@@ -733,10 +733,16 @@ func (root *Root) setVerticalHeader(input string) {
 
 // setHeaderColumn sets the vertical header column position.
 func (root *Root) setHeaderColumn(input string) {
-	num, err := strconv.Atoi(input)
-	if err != nil {
-		root.setMessagef("Set vertical header column: %s", ErrInvalidNumber)
-		return
+	// Confirming the prompt with no input defaults to the first column,
+	// which is the value wanted in the vast majority of cases.
+	num := 1
+	if input != "" {
+		var err error
+		num, err = strconv.Atoi(input)
+		if err != nil {
+			root.setMessagef("Set vertical header column: %s", ErrInvalidNumber)
+			return
+		}
 	}
 	root.Doc.VerticalHeader = 0
 	if root.Doc.HeaderColumn == num {

--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -1975,18 +1975,18 @@ func TestRoot_setHeaderColumn(t *testing.T) {
 		want int
 	}{
 		{
-			name: "testSetHeaderColumnNil",
-			args: args{
-				input: "",
-			},
-			want: 0,
-		},
-		{
 			name: "testSetHeaderColumnInvalid",
 			args: args{
 				input: "invalid",
 			},
 			want: 0,
+		},
+		{
+			name: "testSetHeaderColumnEmptyDefaultsToOne",
+			args: args{
+				input: "",
+			},
+			want: 1,
 		},
 		{
 			name: "testSetHeaderColumn1",


### PR DESCRIPTION
This makes the interactive `header_column` command (default key `Y`) default to the first column when confirmed with no input, so the common case no longer requires typing a value.

As noted in #740, `header_column` currently prompts for a number and reports "invalid number" if you just press Enter. In practice the value is almost always `1` (pin the first column as a vertical header), so requiring it to be typed every time is a small but constant bit of friction. With this change, confirming the prompt with an empty input sets the header column to `1`; any non-empty value is still parsed and validated exactly as before, and a non-numeric entry still reports an invalid number. Existing behavior for explicit values is unchanged.

The change is scoped to `setHeaderColumn`, which is only reached from the interactive prompt's confirm handler, so nothing else is affected.

Testing: updated `TestRoot_setHeaderColumn` so the empty-input case now expects `1`, and ran `go test ./...` (all packages pass) plus `go vet ./oviewer/` and `gofmt`.
