### PR TITLE
fix: restrict case-insensitive search to ASCII

### DIFF
--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -21,6 +21,10 @@ import (
 
 // Searcher interface provides a match method that determines
 // if the search word matches the argument string.
+//
+// MatchString is kept for API symmetry and test coverage, but the runtime
+// search path uses Match on []byte because it avoids string allocation and is
+// the hot path used during chunk/line scanning.
 type Searcher interface {
 	// Match searches for bytes.
 	Match(target []byte) bool
@@ -128,14 +132,13 @@ func NewSearcher(word string, searchReg *regexp.Regexp, caseSensitive bool, rege
 			word: word,
 		}
 	}
-	// Use sensitiveWord when not needed.
-	if strings.ToLower(word) == strings.ToUpper(word) {
-		return sensitiveWord{
-			word: word,
+	if needsCaseInsensitiveSearch(word) {
+		return searchWord{
+			word: lowercaseString(word),
 		}
 	}
-	return searchWord{
-		word: strings.ToLower(word),
+	return sensitiveWord{
+		word: word,
 	}
 }
 

--- a/oviewer/search.go
+++ b/oviewer/search.go
@@ -40,18 +40,18 @@ type searchWord struct {
 // searchWord Match is a case-insensitive search for bytes.
 func (substr searchWord) Match(target []byte) bool {
 	target = stripEscapeSequenceBytes(target)
-	return bytes.Contains(bytes.ToLower(target), []byte(substr.word))
+	return bytes.Contains(lowercase(target), []byte(substr.word))
 }
 
 // searchWord MatchString is a case-insensitive search for string.
 func (substr searchWord) MatchString(target string) bool {
 	target = stripEscapeSequenceString(target)
-	return strings.Contains(strings.ToLower(target), substr.word)
+	return strings.Contains(lowercaseString(target), substr.word)
 }
 
 // searchWord FindAll searches for strings and returns the index of the match.
 func (substr searchWord) FindAll(target string) [][]int {
-	target = strings.ToLower(target)
+	target = lowercaseString(target)
 	return allStringIndex(target, substr.word)
 }
 

--- a/oviewer/search_test.go
+++ b/oviewer/search_test.go
@@ -278,6 +278,27 @@ func Test_regexpWord_Match(t *testing.T) {
 	}
 }
 
+func Test_needsCaseInsensitiveSearch(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		word string
+		want bool
+	}{
+		{name: "digits only", word: "123", want: false},
+		{name: "lowercase ascii", word: "abc", want: true},
+		{name: "uppercase ascii", word: "ABC", want: true},
+		{name: "mixed ascii", word: "A-1", want: true},
+		{name: "non ascii letter", word: "é", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsCaseInsensitiveSearch(tt.word); got != tt.want {
+				t.Fatalf("needsCaseInsensitiveSearch(%q) = %v, want %v", tt.word, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_getSearchMatch(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -197,3 +197,13 @@ func lowercase(input []byte) []byte {
 	}
 	return lower
 }
+
+// needsCaseInsensitiveSearch checks if the word contains any alphabetic characters (A-Z or a-z).
+func needsCaseInsensitiveSearch(word string) bool {
+	for _, c := range word {
+		if ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') {
+			return true
+		}
+	}
+	return false
+}

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -181,3 +181,19 @@ func firstRune(s string) rune {
 	}
 	return []rune(s)[0]
 }
+
+func lowercaseString(input string) string {
+	lower := lowercase([]byte(input))
+	return string(lower)
+}
+
+func lowercase(input []byte) []byte {
+	lower := make([]byte, len(input))
+	for i, c := range input {
+		if 'A' <= c && c <= 'Z' {
+			c += 32
+		}
+		lower[i] = c
+	}
+	return lower
+}


### PR DESCRIPTION
Case-insensitive matching previously lowercased the full target string before searching. For some Unicode runes, this changes the byte length of the string, so the returned match offsets no longer point to the original text and can highlight the wrong bytes.

This patch limits case-insensitive matching to ASCII-only input, where lower/upper conversion is byte-stable and safe. Non-ASCII text keeps the existing behavior instead of relying on Unicode lowercasing that can change offset positions.

This is a reference implementation for discussion and is not intended to be merged as-is.