### PR TITLE
fix: plain text search skips a quoted section after a match

### DIFF
--- a/oviewer/search_test.go
+++ b/oviewer/search_test.go
@@ -798,6 +798,35 @@ func Test_sensitive_FindAll(t *testing.T) {
 			},
 			want: [][]int{{0, 3}},
 		},
+		{
+			// A double quote is an ordinary character in a plain text search,
+			// so a match immediately before one must not hide the matches
+			// inside the quoted section.
+			name: "testQuoted",
+			fields: fields{
+				searchWord:    "=",
+				searchReg:     regexpCompile("=", true),
+				caseSensitive: true,
+				regexpSearch:  false,
+			},
+			args: args{
+				s: `msg="a=b" level=info`,
+			},
+			want: [][]int{{3, 4}, {6, 7}, {15, 16}},
+		},
+		{
+			name: "testQuotedInsensitive",
+			fields: fields{
+				searchWord:    "A",
+				searchReg:     regexpCompile("A", false),
+				caseSensitive: false,
+				regexpSearch:  false,
+			},
+			args: args{
+				s: `a"a"a`,
+			},
+			want: [][]int{{0, 1}, {2, 3}, {4, 5}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -102,24 +102,18 @@ func skipQuoted(s string, offSet int) (string, int) {
 }
 
 // allStringIndex returns all matching string positions.
+// It is used by the plain text search, where a double quote is an ordinary
+// character, so every occurrence is reported.
 func allStringIndex(s string, substr string) [][]int {
 	if len(substr) == 0 {
 		return nil
 	}
 	var result [][]int
 	width := len(substr)
-	for pos, offSet := strings.Index(s, substr), 0; pos != -1; {
+	for pos, offSet := strings.Index(s, substr), 0; pos != -1; pos = strings.Index(s, substr) {
 		s = s[pos+width:]
 		result = append(result, []int{pos + offSet, pos + offSet + width})
 		offSet += pos + width
-
-		if len(s) > 0 && s[0] == '"' {
-			qpos := strings.Index(s[1:], `"`)
-			s = s[qpos+2:]
-			offSet += qpos + 2
-		}
-
-		pos = strings.Index(s, substr)
 	}
 	return result
 }

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -481,6 +481,8 @@ func Test_allStringIndex(t *testing.T) {
 			want: nil,
 		},
 		{
+			// A double quote has no special meaning here, so the delimiter
+			// inside the quoted field is reported as well.
 			name: "testDoubleQuote",
 			args: args{
 				s:      `a,"b,c",d`,
@@ -488,6 +490,7 @@ func Test_allStringIndex(t *testing.T) {
 			},
 			want: [][]int{
 				{1, 2},
+				{4, 5},
 				{7, 8},
 			},
 		},
@@ -500,6 +503,32 @@ func Test_allStringIndex(t *testing.T) {
 			want: [][]int{
 				{1, 2},
 				{9, 10},
+			},
+		},
+		{
+			// A match immediately followed by a double quote must not hide the
+			// matches inside the quoted section.
+			name: "testMatchBeforeQuote",
+			args: args{
+				s:      `msg="a=b" level=info`,
+				substr: "=",
+			},
+			want: [][]int{
+				{3, 4},
+				{6, 7},
+				{15, 16},
+			},
+		},
+		{
+			name: "testMatchInsideQuote",
+			args: args{
+				s:      `a"a"a`,
+				substr: "a",
+			},
+			want: [][]int{
+				{0, 1},
+				{2, 3},
+				{4, 5},
 			},
 		},
 	}


### PR DESCRIPTION
A plain text search skips over an entire double-quoted section whenever a match ends immediately before a `"`, so matches inside that section are never highlighted.

Searching `=` in `msg="a=b" level=info`, with the search highlight shown as `^[[7m`:

```
before: msg^[[7m=^[[0m"a=b" level^[[7m=^[[0minfo
after:  msg^[[7m=^[[0m"a^[[7m=^[[0mb" level^[[7m=^[[0minfo
```

The `=` inside the quotes is missed because the match at index 3 is followed by `"`, and `allStringIndex` then jumps past the whole quoted field.

That quote skipping is a CSV delimiter rule. It was already split out into `allDelimiterIndex` in 9db128a, and this removes the leftover copy from `allStringIndex`, whose only remaining callers are the two search `FindAll` methods in `search.go`. Column separation is unaffected.

One existing expectation changes: `Test_allStringIndex/testDoubleQuote` goes from `[[1 2] [7 8]]` to `[[1 2] [4 5] [7 8]]`. That case was asserting CSV behaviour on the search function; the equivalent CSV assertion still lives in `Test_allDelimiterIndex/testDoubleQuote`, unchanged.

Full suite passes, `gofmt` and `go vet` clean.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
