### PR TITLE
fix: an escaped double quote splits a column at a delimiter inside the field

### DIFF
--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -94,11 +94,23 @@ func allDelimiterIndex(s string, substr string) [][]int {
 }
 
 // skipQuoted skips the double-quoted field at the beginning of s and returns
-// the remainder with the updated offset. An unclosed quote skips only the
-// opening quote, which is what the delimiter search did before.
+// the remainder with the updated offset. A doubled "" is an escaped quote and
+// stays inside the field. An unclosed quote skips only the opening quote,
+// which is what the delimiter search did before.
 func skipQuoted(s string, offSet int) (string, int) {
-	qpos := strings.Index(s[1:], `"`)
-	return s[qpos+2:], offSet + qpos + 2
+	for i := 1; i < len(s); {
+		q := strings.IndexByte(s[i:], '"')
+		if q < 0 {
+			break
+		}
+		i += q
+		if i+1 < len(s) && s[i+1] == '"' {
+			i += 2
+			continue
+		}
+		return s[i+1:], offSet + i + 1
+	}
+	return s[1:], offSet + 1
 }
 
 // allStringIndex returns all matching string positions.

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -631,6 +631,27 @@ func Test_allDelimiterIndex(t *testing.T) {
 				{2, 3},
 			},
 		},
+		{
+			name: "testLeadingEscapedDoubleQuote",
+			args: args{
+				s:      `"a""b,c",d`,
+				substr: ",",
+			},
+			want: [][]int{
+				{8, 9},
+			},
+		},
+		{
+			name: "testEscapedDoubleQuote",
+			args: args{
+				s:      `a,"b""c,d",e`,
+				substr: ",",
+			},
+			want: [][]int{
+				{1, 2},
+				{10, 11},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
`skipQuoted` stops at the first `"` it finds after the opening one, so an escaped `""` ends the skip early and a delimiter that is inside the field gets reported as a column separator.

```
$ printf '"a""b,c",d\nxx,yy\n' > q.csv
$ ov --align --column-delimiter , --exit-write --quit-if-one-screen q.csv

before: xx   ,yy         first column read as `"a""b`, width 5
after:  xx      ,yy      first column read as `"a""b,c"`, width 8
```

This is the same shape as #1156, one case over. That one handled a quoted field at the start of the line; this one is the escaped quote inside it.

Checked against `encoding/csv` over every string up to length 7 drawn from `{a, comma, doublequote}`, 3280 inputs. On the 858 that `encoding/csv` accepts, the old code disagreed on 42 and the new code on none. There is no input where the old answer was right and the new one wrong.

Behaviour is unchanged for any line with no `""` in it, verified over that same corpus. On a malformed line, meaning an unterminated quote, the scan can now run past `""` pairs and report a different column count than before. Both answers are arbitrary there, so I mention it rather than claim the change is universally invisible.

The loop uses `strings.IndexByte` rather than scanning a byte at a time. That matters because this runs per visible line per redraw: on a 10 KB quoted field a scalar loop measured 3526 ns/op against the old 121 ns/op, while `IndexByte` is 142 ns/op and gives byte-for-byte identical results to the scalar version across the whole corpus.

Two test cases added. Both fail against the old implementation. `go test ./...` is green before and after.

AI disclosure: written with Claude Code. I ran the binary before and after, ran the corpus comparison and the benchmarks myself.
