### PR TITLE
Apply go fix for go1.26 and simplify space checks

### DIFF
--- a/oviewer/action_test.go
+++ b/oviewer/action_test.go
@@ -2266,7 +2266,7 @@ func TestRoot_setViewMode(t *testing.T) {
 				modeName: "",
 			},
 			general: General{
-				Converter: strPtr("es"),
+				Converter: new("es"),
 			},
 			wantErr:       false,
 			wantMessage:   "",
@@ -2279,7 +2279,7 @@ func TestRoot_setViewMode(t *testing.T) {
 			},
 			ViewMode: "General",
 			general: General{
-				Converter: strPtr("es"),
+				Converter: new("es"),
 			},
 			wantErr:       false,
 			wantMessage:   "Set mode general",
@@ -2293,8 +2293,8 @@ func TestRoot_setViewMode(t *testing.T) {
 				modeName: "custom",
 			},
 			general: General{
-				Caption:   strPtr("Custom Mode"),
-				Converter: strPtr("align"),
+				Caption:   new("Custom Mode"),
+				Converter: new("align"),
 			},
 			wantErr:       false,
 			wantMessage:   "Set mode custom",
@@ -2308,7 +2308,7 @@ func TestRoot_setViewMode(t *testing.T) {
 				modeName: "not",
 			},
 			general: General{
-				Caption: strPtr("Not Found Mode"),
+				Caption: new("Not Found Mode"),
 			},
 			wantErr:     true,
 			wantMessage: "view mode not found: not",

--- a/oviewer/content.go
+++ b/oviewer/content.go
@@ -1,6 +1,7 @@
 package oviewer
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/gdamore/tcell/v3"
@@ -356,8 +357,8 @@ func (pos widthPos) n(x int) int {
 		}
 	}
 	// It should return the last byte of a multi-byte character.
-	for i := len(pos) - 1; i >= 0; i-- {
-		if pos[i] == x {
+	for i, po := range slices.Backward(pos) {
+		if po == x {
 			return i
 		}
 	}

--- a/oviewer/move_leftright.go
+++ b/oviewer/move_leftright.go
@@ -1,5 +1,7 @@
 package oviewer
 
+import "slices"
+
 // columnMargin is the number of characters in the left and right margins of the screen.
 const columnMargin = 2
 
@@ -81,8 +83,8 @@ func (m *Document) optimalCursor(scr SCR, cursor int) int {
 		return len(columns) - 1
 	}
 	if cl > rightLimit {
-		for n := len(columns) - 1; n >= 0; n-- {
-			if columns[n].end < rightLimit {
+		for n, column := range slices.Backward(columns) {
+			if column.end < rightLimit {
 				return n
 			}
 		}

--- a/oviewer/move_updown.go
+++ b/oviewer/move_updown.go
@@ -3,6 +3,7 @@ package oviewer
 import (
 	"context"
 	"log"
+	"slices"
 	"sync/atomic"
 )
 
@@ -126,8 +127,8 @@ func (m *Document) numOfWrap(lX int, lN int) int {
 
 // numOfReverseSlice returns what number x is from the back of slice.
 func numOfReverseSlice(listX []int, x int) int {
-	for n := len(listX) - 1; n >= 0; n-- {
-		if listX[n] <= x {
+	for n, l := range slices.Backward(listX) {
+		if l <= x {
 			return n
 		}
 	}

--- a/oviewer/prepare_draw.go
+++ b/oviewer/prepare_draw.go
@@ -319,15 +319,15 @@ func trimWidth(lc contents) (int, int) {
 // trimmedIndices returns the start and end of the trimmed contents.
 func trimmedIndices(lc contents) (int, int) {
 	ts := 0
-	for i := range lc {
-		if !lc.IsSpace(i) {
+	for i, c := range lc {
+		if c.str != " " {
 			ts = i
 			break
 		}
 	}
 	te := len(lc)
-	for i := len(lc) - 1; i >= 0; i-- {
-		if !lc.IsSpace(i) {
+	for i, l := range slices.Backward(lc) {
+		if l.str != " " {
 			te = i + 1
 			break
 		}
@@ -539,8 +539,8 @@ func (root *Root) multiColorHighlight(lineC LineC) {
 	if numC == 0 {
 		return
 	}
-	for i := len(root.Doc.multiColorRegexps) - 1; i >= 0; i-- {
-		indexes := searchPositionReg(lineC.str, root.Doc.multiColorRegexps[i])
+	for i, v := range slices.Backward(root.Doc.multiColorRegexps) {
+		indexes := searchPositionReg(lineC.str, v)
 		for _, idx := range indexes {
 			RangeStyle(lineC.lc, lineC.pos.x(idx[0]), lineC.pos.x(idx[1]), root.Doc.Style.MultiColorHighlight[i%numC])
 		}
@@ -689,7 +689,7 @@ func findColumnEnd(lc contents, indexes []int, n int, start int) int {
 // findPrevSpace returns the position of the previous space.
 func findPrevSpace(lc contents, start int) int {
 	for p := start; p > 0; p-- {
-		if lc.IsSpace(p) {
+		if lc[p].str == " " {
 			return p
 		}
 	}
@@ -699,7 +699,7 @@ func findPrevSpace(lc contents, start int) int {
 // findNextSpace returns the position of the next space or the end of contents.
 func findNextSpace(lc contents, start int) int {
 	for p := start; p < len(lc); p++ {
-		if lc.IsSpace(p) {
+		if lc[p].str == " " {
 			return p
 		}
 	}

--- a/oviewer/runtime_settings_test.go
+++ b/oviewer/runtime_settings_test.go
@@ -5,18 +5,6 @@ import (
 	"testing"
 )
 
-func intPtr(i int) *int {
-	return &i
-}
-
-func strPtr(s string) *string {
-	return &s
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func Test_updateRuntimeSettings(t *testing.T) {
 	type args struct {
 		runtime       RunTimeSettings
@@ -49,8 +37,8 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					Header:   1,
 				},
 				configGeneral: General{
-					TabWidth: intPtr(8),
-					Header:   intPtr(2),
+					TabWidth: new(8),
+					Header:   new(2),
 				},
 			},
 			want: RunTimeSettings{
@@ -65,8 +53,8 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					SkipLines: 3,
 				},
 				configGeneral: General{
-					TabWidth: intPtr(8),
-					Header:   intPtr(2),
+					TabWidth: new(8),
+					Header:   new(2),
 				},
 			},
 			want: RunTimeSettings{
@@ -83,9 +71,9 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					ColumnMode: true,
 				},
 				configGeneral: General{
-					TabWidth:  intPtr(8),
-					Header:    intPtr(2),
-					SkipLines: intPtr(3),
+					TabWidth:  new(8),
+					Header:    new(2),
+					SkipLines: new(3),
 				},
 			},
 			want: RunTimeSettings{
@@ -103,10 +91,10 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					LineNumMode: true,
 				},
 				configGeneral: General{
-					TabWidth:   intPtr(8),
-					Header:     intPtr(2),
-					SkipLines:  intPtr(3),
-					ColumnMode: boolPtr(true),
+					TabWidth:   new(8),
+					Header:     new(2),
+					SkipLines:  new(3),
+					ColumnMode: new(true),
 				},
 			},
 			want: RunTimeSettings{
@@ -126,12 +114,12 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					FollowMode: true,
 				},
 				configGeneral: General{
-					TabWidth:    intPtr(8),
-					Header:      intPtr(2),
-					SkipLines:   intPtr(3),
-					ColumnMode:  boolPtr(true),
-					ColumnWidth: boolPtr(true),
-					LineNumMode: boolPtr(true),
+					TabWidth:    new(8),
+					Header:      new(2),
+					SkipLines:   new(3),
+					ColumnMode:  new(true),
+					ColumnWidth: new(true),
+					LineNumMode: new(true),
 				},
 			},
 			want: RunTimeSettings{
@@ -153,14 +141,14 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					FollowSection: true,
 				},
 				configGeneral: General{
-					TabWidth:    intPtr(8),
-					Header:      intPtr(2),
-					SkipLines:   intPtr(3),
-					ColumnMode:  boolPtr(true),
-					ColumnWidth: boolPtr(true),
-					LineNumMode: boolPtr(true),
-					WrapMode:    boolPtr(false),
-					FollowMode:  boolPtr(true),
+					TabWidth:    new(8),
+					Header:      new(2),
+					SkipLines:   new(3),
+					ColumnMode:  new(true),
+					ColumnWidth: new(true),
+					LineNumMode: new(true),
+					WrapMode:    new(false),
+					FollowMode:  new(true),
 				},
 			},
 			want: RunTimeSettings{
@@ -184,16 +172,16 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					ColumnDelimiter: ",",
 				},
 				configGeneral: General{
-					TabWidth:      intPtr(8),
-					Header:        intPtr(2),
-					SkipLines:     intPtr(3),
-					ColumnMode:    boolPtr(true),
-					ColumnWidth:   boolPtr(true),
-					LineNumMode:   boolPtr(true),
-					WrapMode:      boolPtr(false),
-					FollowMode:    boolPtr(true),
-					FollowAll:     boolPtr(true),
-					FollowSection: boolPtr(true),
+					TabWidth:      new(8),
+					Header:        new(2),
+					SkipLines:     new(3),
+					ColumnMode:    new(true),
+					ColumnWidth:   new(true),
+					LineNumMode:   new(true),
+					WrapMode:      new(false),
+					FollowMode:    new(true),
+					FollowAll:     new(true),
+					FollowSection: new(true),
 				},
 			},
 			want: RunTimeSettings{
@@ -219,18 +207,18 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					MarkStyleWidth: 2,
 				},
 				configGeneral: General{
-					TabWidth:        intPtr(8),
-					Header:          intPtr(2),
-					SkipLines:       intPtr(3),
-					ColumnMode:      boolPtr(true),
-					ColumnWidth:     boolPtr(true),
-					LineNumMode:     boolPtr(true),
-					WrapMode:        boolPtr(false),
-					FollowMode:      boolPtr(true),
-					FollowAll:       boolPtr(true),
-					FollowSection:   boolPtr(true),
-					FollowName:      boolPtr(true),
-					ColumnDelimiter: strPtr(","),
+					TabWidth:        new(8),
+					Header:          new(2),
+					SkipLines:       new(3),
+					ColumnMode:      new(true),
+					ColumnWidth:     new(true),
+					LineNumMode:     new(true),
+					WrapMode:        new(false),
+					FollowMode:      new(true),
+					FollowAll:       new(true),
+					FollowSection:   new(true),
+					FollowName:      new(true),
+					ColumnDelimiter: new(","),
 				},
 			},
 			want: RunTimeSettings{
@@ -258,20 +246,20 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					SectionStartPosition: 5,
 				},
 				configGeneral: General{
-					TabWidth:        intPtr(8),
-					Header:          intPtr(2),
-					SkipLines:       intPtr(3),
-					ColumnMode:      boolPtr(true),
-					ColumnWidth:     boolPtr(true),
-					LineNumMode:     boolPtr(true),
-					WrapMode:        boolPtr(false),
-					FollowMode:      boolPtr(true),
-					FollowAll:       boolPtr(true),
-					FollowSection:   boolPtr(true),
-					FollowName:      boolPtr(true),
-					ColumnDelimiter: strPtr(","),
-					WatchInterval:   intPtr(10),
-					MarkStyleWidth:  intPtr(2),
+					TabWidth:        new(8),
+					Header:          new(2),
+					SkipLines:       new(3),
+					ColumnMode:      new(true),
+					ColumnWidth:     new(true),
+					LineNumMode:     new(true),
+					WrapMode:        new(false),
+					FollowMode:      new(true),
+					FollowAll:       new(true),
+					FollowSection:   new(true),
+					FollowName:      new(true),
+					ColumnDelimiter: new(","),
+					WatchInterval:   new(10),
+					MarkStyleWidth:  new(2),
 				},
 			},
 			want: RunTimeSettings{
@@ -300,7 +288,7 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					Caption: "test caption",
 				},
 				configGeneral: General{
-					Wrap: strPtr("word"),
+					Wrap: new("word"),
 				},
 			},
 			want: RunTimeSettings{
@@ -316,7 +304,7 @@ func Test_updateRuntimeSettings(t *testing.T) {
 					Caption: "test caption",
 				},
 				configGeneral: General{
-					Wrap: strPtr("false"),
+					Wrap: new("false"),
 				},
 			},
 			want: RunTimeSettings{
@@ -461,37 +449,37 @@ func Test_updateRuntimeSettings_AllFields(t *testing.T) {
 					Converter:            convAlign,
 				},
 				configGeneral: General{
-					TabWidth:             intPtr(8),
-					Header:               intPtr(2),
-					VerticalHeader:       intPtr(3),
-					HeaderColumn:         intPtr(4),
-					SkipLines:            intPtr(6),
-					WatchInterval:        intPtr(15),
-					MarkStyleWidth:       intPtr(3),
-					SectionStartPosition: intPtr(7),
-					SectionHeaderNum:     intPtr(2),
-					HScrollWidth:         strPtr("20%"),
-					HScrollWidthNum:      intPtr(20),
-					RulerType:            (*RulerType)(intPtr(int(RulerAbsolute))),
-					AlternateRows:        boolPtr(false),
-					ColumnMode:           boolPtr(false),
-					ColumnWidth:          boolPtr(false),
-					ColumnRainbow:        boolPtr(false),
-					LineNumMode:          boolPtr(false),
-					WrapMode:             boolPtr(false),
-					FollowMode:           boolPtr(false),
-					FollowAll:            boolPtr(false),
-					FollowSection:        boolPtr(false),
-					FollowName:           boolPtr(false),
-					PlainMode:            boolPtr(false),
-					SectionHeader:        boolPtr(false),
-					HideOtherSection:     boolPtr(false),
-					ColumnDelimiter:      strPtr("\t"),
-					SectionDelimiter:     strPtr("###"),
-					JumpTarget:           strPtr("newTarget"),
+					TabWidth:             new(8),
+					Header:               new(2),
+					VerticalHeader:       new(3),
+					HeaderColumn:         new(4),
+					SkipLines:            new(6),
+					WatchInterval:        new(15),
+					MarkStyleWidth:       new(3),
+					SectionStartPosition: new(7),
+					SectionHeaderNum:     new(2),
+					HScrollWidth:         new("20%"),
+					HScrollWidthNum:      new(20),
+					RulerType:            (*RulerType)(new(int(RulerAbsolute))),
+					AlternateRows:        new(false),
+					ColumnMode:           new(false),
+					ColumnWidth:          new(false),
+					ColumnRainbow:        new(false),
+					LineNumMode:          new(false),
+					WrapMode:             new(false),
+					FollowMode:           new(false),
+					FollowAll:            new(false),
+					FollowSection:        new(false),
+					FollowName:           new(false),
+					PlainMode:            new(false),
+					SectionHeader:        new(false),
+					HideOtherSection:     new(false),
+					ColumnDelimiter:      new("\t"),
+					SectionDelimiter:     new("###"),
+					JumpTarget:           new("newTarget"),
 					MultiColorWords:      &[]string{"newWord1", "newWord2"},
-					Caption:              strPtr("new caption"),
-					Converter:            strPtr(convRaw),
+					Caption:              new("new caption"),
+					Converter:            new(convRaw),
 				},
 			},
 			want: RunTimeSettings{
@@ -535,7 +523,7 @@ func Test_updateRuntimeSettings_AllFields(t *testing.T) {
 					Converter: convEscaped,
 				},
 				configGeneral: General{
-					Align: boolPtr(true),
+					Align: new(true),
 				},
 			},
 			want: RunTimeSettings{
@@ -549,7 +537,7 @@ func Test_updateRuntimeSettings_AllFields(t *testing.T) {
 					Converter: convEscaped,
 				},
 				configGeneral: General{
-					Raw: boolPtr(true),
+					Raw: new(true),
 				},
 			},
 			want: RunTimeSettings{


### PR DESCRIPTION
- Replace strPtr/intPtr/boolPtr helpers with the built-in new() (go fix, go1.26+)
- Replace manual reverse loops with slices.Backward
- Inline lc.IsSpace calls in trimmedIndices, findPrevSpace, and findNextSpace to avoid redundant bounds checks and method call overhead