### PR TITLE
fix: the escape strip fast path never matches a backspace

### DIFF
--- a/oviewer/utils.go
+++ b/oviewer/utils.go
@@ -148,7 +148,7 @@ func writeLine(w io.Writer, line []byte) {
 var stripRegexpES = regexp.MustCompile("(\x1b\\[[\\d;*]*m)|.\\x08")
 
 func stripEscapeSequenceString(src string) string {
-	if !strings.ContainsAny(src, "\x1b\\x08") {
+	if !strings.ContainsAny(src, "\x1b\x08") {
 		return src
 	}
 	// Remove EscapeSequence.

--- a/oviewer/utils_test.go
+++ b/oviewer/utils_test.go
@@ -706,3 +706,71 @@ func Test_abs(t *testing.T) {
 		})
 	}
 }
+
+func Test_stripEscapeSequenceString(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		src string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "testEmpty",
+			args: args{
+				src: "",
+			},
+			want: "",
+		},
+		{
+			name: "testPlain",
+			args: args{
+				src: "plain text",
+			},
+			want: "plain text",
+		},
+		{
+			name: "testSGR",
+			args: args{
+				src: "\x1b[31mred\x1b[m",
+			},
+			want: "red",
+		},
+		{
+			name: "testBackspace",
+			args: args{
+				src: "ab\bc",
+			},
+			want: "ac",
+		},
+		{
+			name: "testOverstrikeUnderline",
+			args: args{
+				src: "_\bp_\ba_\bg",
+			},
+			want: "pag",
+		},
+		{
+			name: "testOverstrikeBold",
+			args: args{
+				src: "p\bpa\bag\bg",
+			},
+			want: "pag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripEscapeSequenceString(tt.args.src)
+			if got != tt.want {
+				t.Errorf("stripEscapeSequenceString() = %q, want %q", got, tt.want)
+			}
+			// The string and byte versions must agree on every input.
+			if gotBytes := string(stripEscapeSequenceBytes([]byte(tt.args.src))); gotBytes != got {
+				t.Errorf("stripEscapeSequenceBytes() = %q, want %q", gotBytes, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The fast path in `stripEscapeSequenceString` uses the cutset `"\x1b\\x08"`, which Go reads as the five runes ESC, backslash, `x`, `0`, `8`. Byte `0x08` is not among them, so a string whose only trigger is a backspace returns early and is never stripped. The byte sibling nine lines below already uses `"\x1b\x08"`.

```
stripEscapeSequenceString("ab\bc")        -> "ab\bc"   (want "ac")
stripEscapeSequenceBytes([]byte("ab\bc")) -> "ac"
```

The effect is that the two halves of `Searcher` disagree. Over 13 inputs, 9 words and the 3 searcher kinds, `Match` and `MatchString` differ on 19 combinations before this and none after. Searching `name` in man page output `N\bNA\bAM\bME\bE` is the ordinary case: `Match` finds the line, `MatchString` does not. The divergence ran both ways, so it was not one side simply being stricter.

The pager is not affected. Every internal search path calls `Match`, and `Searcher.MatchString` has no non-test callers in the repo, so only library users see this. `FindAll` runs on already parsed text and is untouched.

It is also a little faster: ordinary text containing an `x`, `0`, `8` or backslash used to run the regexp for nothing, and a mixed 1000 line log corpus drops from 1.85ms to 0.61ms. Backspace-heavy input now costs what `Match` already costs, 1.60ms against 1.58ms.

Test covers SGR, both overstrike forms and plain text, and asserts the string and byte versions agree on each input. It fails if either branch of the regexp is removed.

AI disclosure: written with Claude Code. I ran the corpus comparison and the benchmarks myself.
