### PR TITLE
fix: guess column width from the parsed line, not the raw bytes

### DIFF
--- a/oviewer/document.go
+++ b/oviewer/document.go
@@ -789,7 +789,8 @@ func (m *Document) setColumnWidths() {
 	lines := m.store.chunks[0].lines[m.SkipLines:tl]
 	buf := make([]string, len(lines))
 	for n, line := range lines {
-		buf[n] = string(line)
+		// Strip escape sequences because the guessed widths are used against the parsed contents.
+		buf[n] = string(stripEscapeSequenceBytes(line))
 	}
 	// Stop guessing if valid row count is not reached.
 	if !m.BufEOF() && len(buf) < 20 {

--- a/oviewer/prepare_draw_test.go
+++ b/oviewer/prepare_draw_test.go
@@ -645,6 +645,52 @@ func TestDocument_setColumnWidthsSkipLines(t *testing.T) {
 	}
 }
 
+func TestDocument_setColumnWidthsEscapeSequence(t *testing.T) {
+	// The column widths are used against the parsed contents,
+	// so escape sequences must not shift the guessed boundaries.
+	plain := "NAME    AGE   CITY\n" +
+		"alice   30    paris\n" +
+		"bob     25    tokyo\n" +
+		"carol   41    lima\n"
+	pm := docHelper(t, plain)
+	pm.ColumnWidth = true
+	pm.setColumnWidths()
+	want := pm.columnWidths
+	if len(want) == 0 {
+		t.Fatal("plain columnWidths is empty")
+	}
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "sgr",
+			content: "NAME    \x1b[31mAGE\x1b[0m   CITY\n" +
+				"alice   \x1b[31m30\x1b[0m    paris\n" +
+				"bob     \x1b[31m25\x1b[0m    tokyo\n" +
+				"carol   \x1b[31m41\x1b[0m    lima\n",
+		},
+		{
+			name: "overstrike",
+			content: "NAME    AGE   CITY\n" +
+				"a\bal\bli\bic\bce\be   30    paris\n" +
+				"b\bbo\bob\bb     25    tokyo\n" +
+				"c\bca\bar\bro\bol\bl   41    lima\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := docHelper(t, tt.content)
+			m.ColumnWidth = true
+			m.setColumnWidths()
+			if !reflect.DeepEqual(m.columnWidths, want) {
+				t.Errorf("columnWidths got: %v, want: %v", m.columnWidths, want)
+			}
+		})
+	}
+}
+
 func TestRoot_searchHighlight(t *testing.T) {
 	tcellNewScreen = fakeScreen
 	searchHighlight := tcell.StyleDefault.Reverse(true)


### PR DESCRIPTION
`setColumnWidths` hands `guesswidth` the raw chunk bytes, but every consumer of `columnWidths` indexes into the parsed contents, where escapes are already gone. So each sequence shifts the boundaries by its own byte length and columns get fused. `store.go:389` already strips the same `chunk.lines` slice with the repo's helper.

```
$ ov --column-mode --column-width --column-rainbow -H1 -X -F tbl.txt
plain:   root |    1 | systemd      3 columns, widths [5 11]
ansi:    root     1  systemd       2 columns, widths [10 16]
```

Two limits worth stating. `stripRegexpES` covers SGR and backspace only, so the guess now agrees with the parsed line for those and no others: OSC 8 hyperlinks, `ESC[2J`, `ESC[H` and an unterminated ESC are still removed by `StrToContents` and not here. Mixing SGR with one of those can turn an empty guess into a wrong split, no further from truth but visible.

Second, it costs time. On a 1000 line coloured table the guess goes from 546us to 2.61ms, once per load when it succeeds. When it returns empty the result is not cached, because `prepare_draw.go:147` keys on `len(columnWidths) == 0`, so the work repeats every draw and coloured input there goes 403us to 1.17ms on a 50ms tick. That retry loop predates this change. An "already tried" flag would remove the repeat and this regression with it, and I would rather send that separately than touch the draw loop here.

Test asserts coloured and overstruck input give the same widths as the identical plain input. It fails if either regexp branch goes.

AI disclosure: written with Claude Code. I ran the binary, the width comparison and the benchmarks myself.
